### PR TITLE
Pulls db access out for better testing

### DIFF
--- a/quark/db/models.py
+++ b/quark/db/models.py
@@ -132,7 +132,9 @@ class IPAddress(BASEV2, HasId, HasTenant):
     @deallocated.setter
     def deallocated(self, val):
         self._deallocated = val
-        self.deallocated_at = timeutils.utcnow()
+        self.deallocated_at = None
+        if val:
+            self.deallocated_at = timeutils.utcnow()
 
     # TODO(jkoelker) update the expression to use the jointable as well
     @deallocated.expression
@@ -200,7 +202,8 @@ class Subnet(BASEV2, HasId, HasTenant, IsHazTags):
                                      'IPAddress.subnet_id, '
                                      'IPAddress._deallocated!=1)',
                                      backref="subnet")
-    routes = orm.relationship(Route, backref='subnet', cascade='delete')
+    routes = orm.relationship(Route, primaryjoin="Route.subnet_id==Subnet.id",
+                              backref='subnet', cascade='delete')
 
 
 port_ip_association_table = sa.Table(

--- a/quark/exceptions.py
+++ b/quark/exceptions.py
@@ -11,3 +11,7 @@ class RouteNotFound(exceptions.NotFound):
 
 class AmbigiousLswitchCount(exceptions.QuantumException):
     message = _("Too many lswitches for network %(net_id)s.")
+
+
+class IpAddressNotFound(exceptions.QuantumException):
+    message = _("IP Address %(addr_id)s not found.")

--- a/quark/tests/test_ipam.py
+++ b/quark/tests/test_ipam.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2013 OpenStack Foundation
+# Copyright (c) 2014 OpenStack Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,14 +13,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from datetime import datetime
+import contextlib
 import mock
-import netaddr
-
 from oslo.config import cfg
 from quantum import context
 from quantum.common import exceptions
-from quantum.db import api as db_api
+from quantum.db import api as quantum_db_api
 
 from quark.db import models
 import quark.ipam
@@ -28,634 +26,271 @@ import quark.ipam
 import test_base
 
 
-class TestQuarkIpamBase(test_base.TestBase):
-    # TODO(amir): test ip_address and version args on ipam.allocate_ip_address
+class QuarkIpamBaseTest(test_base.TestBase):
     def setUp(self):
         cfg.CONF.set_override('sql_connection', 'sqlite://', 'DATABASE')
-        db_api.configure_db()
-        models.BASEV2.metadata.create_all(db_api._ENGINE)
+        quantum_db_api.configure_db()
+        models.BASEV2.metadata.create_all(quantum_db_api._ENGINE)
         self.ipam = quark.ipam.QuarkIpam()
         self.context = context.get_admin_context()
 
     def tearDown(self):
-        db_api.clear_db()
+        quantum_db_api.clear_db()
 
-    def _create_and_insert_mar(self, base='01:02:03:00:00:00', mask=24):
-        first_address = int(base.replace(':', ''), base=16)
-        last_address = first_address + (1 << (48 - mask))
-        mar = models.MacAddressRange(cidr=base + '/' + str(mask),
-                                     first_address=first_address,
-                                     last_address=last_address)
-        self.context.session.add(mar)
-        self.context.session.flush()
 
-    def test_allocate_mac_address_no_ranges(self):
-        net_id = None
-        port_id = None
-        tenant_id = None
-        reuse_after = 0
+class QuarkMacAddressAllocateDeallocated(QuarkIpamBaseTest):
+    @contextlib.contextmanager
+    def _stubs(self, mac_find=True):
+        address = dict(id=1, address=0)
+        mac_range = dict(id=1, first_address=0, last_address=255)
+        db_mod = "quark.db.api"
+        with contextlib.nested(
+            mock.patch("%s.mac_address_find" % db_mod),
+            mock.patch("%s.mac_address_range_find_allocation_counts" % db_mod),
+            mock.patch("%s.mac_address_update" % db_mod),
+            mock.patch("%s.mac_address_create" % db_mod)
+        ) as (addr_find, mac_range_count, mac_update, mac_create):
+            if mac_find:
+                addr_find.return_value = address
+            else:
+                addr_find.side_effect = [None, None]
+            mac_range_count.return_value = [(mac_range, 0)]
+            mac_create.return_value = address
+            yield mac_update, mac_create
 
-        with self.assertRaises(exceptions.MacAddressGenerationFailure):
-            self.ipam.allocate_mac_address(self.context.session,
-                                           net_id,
-                                           port_id,
-                                           tenant_id,
-                                           reuse_after)
+    def test_allocate_mac_address_find_deallocated(self):
+        with self._stubs(True) as (mac_update, mac_create):
+            self.ipam.allocate_mac_address(self.context, 0, 0, 0)
+            self.assertTrue(mac_update.called)
+            self.assertFalse(mac_create.called)
 
-    def test_allocate_mac_address_success(self):
-        net_id = None
-        port_id = None
-        tenant_id = 'foobar'
-        reuse_after = 0
+    def test_allocate_mac_address_creates_new_mac(self):
+        with self._stubs(False) as (mac_update, mac_create):
+            self.ipam.allocate_mac_address(self.context, 0, 0, 0)
+            self.assertFalse(mac_update.called)
+            self.assertTrue(mac_create.called)
 
-        self._create_and_insert_mar()
-        mar = self.context.session.query(models.MacAddressRange).first()
 
-        mac = self.ipam.allocate_mac_address(self.context.session,
-                                             net_id,
-                                             port_id,
-                                             tenant_id,
-                                             reuse_after)
+class QuarkNewMacAddressAllocation(QuarkIpamBaseTest):
+    @contextlib.contextmanager
+    def _stubs(self, addresses=None, ranges=None):
+        if not addresses:
+            addresses = [None]
+        db_mod = "quark.db.api"
+        with contextlib.nested(
+            mock.patch("%s.mac_address_find" % db_mod),
+            mock.patch("%s.mac_address_range_find_allocation_counts" % db_mod),
+        ) as (mac_find, mac_range_count):
+            mac_find.side_effect = addresses
+            mac_range_count.return_value = ranges
+            yield
 
-        self.assertEqual(mac['tenant_id'], tenant_id)
-        self.assertIsNone(mac['created_at'])  # null pre-insert
-        self.assertEqual(mac['address'], mar['first_address'])
-        self.assertEqual(mac['mac_address_range_id'], mar['id'])
-        self.assertFalse(mac['deallocated'])
-        self.assertIsNone(mac['deallocated_at'])
+    def test_allocate_new_mac_address_in_empty_range(self):
+        mar = dict(id=1, first_address=0, last_address=255)
+        with self._stubs(ranges=[(mar, 0)], addresses=[None, None]):
+            address = self.ipam.allocate_mac_address(self.context, 0, 0, 0)
+            self.assertEqual(address["address"], 0)
 
-    def test_allocate_mac_address_deallocated_success(self):
-        net_id = None
-        port_id = None
-        tenant_id = 'foobar'
-        reuse_after = 0
+    def test_allocate_new_mac_in_partially_allocated_range(self):
+        mac = dict(id=1, address=0)
+        mar = dict(id=1, first_address=0, last_address=255)
+        with self._stubs(ranges=[(mar, 0)], addresses=[None, mac]):
+            address = self.ipam.allocate_mac_address(self.context, 0, 0, 0)
+            self.assertEqual(address["address"], 1)
 
-        self._create_and_insert_mar()
-        mar = self.context.session.query(models.MacAddressRange).first()
+    def test_allocate_mac_one_full_one_open_range(self):
+        mar1 = dict(id=1, first_address=0, last_address=1)
+        mar2 = dict(id=2, first_address=2, last_address=255)
+        ranges = [(mar1, 1), (mar2, 0)]
+        with self._stubs(ranges=ranges, addresses=[None, None]):
+            address = self.ipam.allocate_mac_address(self.context, 0, 0, 0)
+            self.assertEqual(address["mac_address_range_id"], 2)
+            self.assertEqual(address["address"], 2)
 
-        mac_deallocated = models.MacAddress(tenant_id=tenant_id,
-                                            address=mar['first_address'],
-                                            mac_address_range_id=mar['id'],
-                                            deallocated=True,
-                                            deallocated_at=datetime(1970,
-                                                                    1,
-                                                                    1))
-        self.context.session.add(mac_deallocated)
-        self.context.session.flush()
+    def test_allocate_mac_no_ranges_fails(self):
+        with self._stubs(ranges=[]):
+            with self.assertRaises(exceptions.MacAddressGenerationFailure):
+                self.ipam.allocate_mac_address(self.context, 0, 0, 0)
 
-        mac = self.ipam.allocate_mac_address(self.context.session,
-                                             net_id,
-                                             port_id,
-                                             tenant_id,
-                                             reuse_after)
+    def test_allocate_mac_no_available_range_fails(self):
+        mar = dict(id=1, first_address=0, last_address=0)
+        ranges = [(mar, 0)]
+        with self._stubs(ranges=ranges):
+            with self.assertRaises(exceptions.MacAddressGenerationFailure):
+                self.ipam.allocate_mac_address(self.context, 0, 0, 0)
 
-        self.assertEqual(mac['tenant_id'], tenant_id)
-        self.assertIsNotNone(mac['created_at'])  # non-null post-insert
-        self.assertEqual(mac['address'], mar['first_address'])
-        self.assertEqual(mac['mac_address_range_id'], mar['id'])
-        self.assertFalse(mac['deallocated'])
-        self.assertIsNone(mac['deallocated_at'])
+    def test_allocate_mac_two_open_ranges_chooses_first(self):
+        mar1 = dict(id=1, first_address=0, last_address=255)
+        mar2 = dict(id=2, first_address=256, last_address=510)
+        ranges = [(mar1, 0), (mar2, 0)]
+        with self._stubs(ranges=ranges, addresses=[None, None]):
+            address = self.ipam.allocate_mac_address(self.context, 0, 0, 0)
+            self.assertEqual(address["mac_address_range_id"], 1)
+            self.assertEqual(address["address"], 0)
 
-    def test_allocate_mac_address_deallocated_failure(self):
-        '''Fails based on the choice of reuse_after argument. Allocates new mac
-        address instead of previously deallocated mac address.'''
-        net_id = None
-        port_id = None
-        tenant_id = 'foobar'
-        reuse_after = 3600
-        test_datetime = datetime(1970, 1, 1)
-        deallocated_at = test_datetime
 
-        self._create_and_insert_mar()
-        mar = self.context.session.query(models.MacAddressRange).first()
+class QuarkMacAddressDeallocation(QuarkIpamBaseTest):
+    @contextlib.contextmanager
+    def _stubs(self, mac):
+        with contextlib.nested(
+            mock.patch("quark.db.api.mac_address_find"),
+            mock.patch("quark.db.api.mac_address_update")
+        ) as (mac_find,
+              mac_update):
+            mac_update.return_value = mac
+            mac_find.return_value = mac
+            yield mac_update
 
-        mac_deallocated = models.MacAddress(tenant_id=tenant_id,
-                                            address=mar['first_address'],
-                                            mac_address_range_id=mar['id'],
-                                            deallocated=True,
-                                            deallocated_at=deallocated_at)
-        self.context.session.add(mac_deallocated)
-        self.context.session.flush()
+    def test_deallocate_mac(self):
+        mac = dict(id=1, address=1)
+        with self._stubs(mac=mac) as mac_update:
+            self.ipam.deallocate_mac_address(self.context, mac["address"])
+            self.assertTrue(mac_update.called)
 
-        with mock.patch('quark.ipam.timeutils') as timeutils:
-            timeutils.utcnow.return_value = test_datetime
-            mac = self.ipam.allocate_mac_address(self.context.session,
-                                                 net_id,
-                                                 port_id,
-                                                 tenant_id,
-                                                 reuse_after)
+    def test_deallocate_mac_mac_not_found_fails(self):
+        with self._stubs(mac=None) as mac_update:
+            self.assertRaises(exceptions.NotFound,
+                              self.ipam.deallocate_mac_address, self.context,
+                              0)
+            self.assertFalse(mac_update.called)
 
-            self.assertEqual(mac['tenant_id'], tenant_id)
-            self.assertIsNone(mac['created_at'])  # null pre-insert
-            self.assertEqual(mac['address'], mar['first_address'] + 1)
-            self.assertEqual(mac['mac_address_range_id'], mar['id'])
-            self.assertFalse(mac['deallocated'])
-            self.assertIsNone(mac['deallocated_at'])
 
-    def test_allocate_mac_address_second_mac(self):
-        net_id = None
-        port_id = None
-        tenant_id = 'foobar'
-        reuse_after = 0
+class QuarkIPAddressDeallocation(QuarkIpamBaseTest):
+    def test_deallocate_ip_address(self):
+        port = dict(ip_addresses=[])
+        addr = dict(ports=[port])
+        port["ip_addresses"].append(addr)
+        self.ipam.deallocate_ip_address(self.context, port)
+        self.assertEqual(len(addr["ports"]), 0)
+        self.assertEqual(addr["deallocated"], True)
 
-        self._create_and_insert_mar()
-        mar = self.context.session.query(models.MacAddressRange).first()
+    def test_deallocate_ip_address_multiple_ports_no_deallocation(self):
+        port = dict(ip_addresses=[])
+        addr = dict(ports=[port, 2], deallocated=False)
+        port["ip_addresses"].append(addr)
 
-        mac = models.MacAddress(tenant_id=tenant_id,
-                                address=mar['first_address'],
-                                mac_address_range_id=mar['id'],
-                                deallocated=False,
-                                deallocated_at=None)
-        self.context.session.add(mac)
-        self.context.session.flush()
+        self.ipam.deallocate_ip_address(self.context, port)
+        self.assertEqual(len(addr["ports"]), 1)
+        self.assertEqual(addr["deallocated"], False)
 
-        mac2 = self.ipam.allocate_mac_address(self.context.session,
-                                              net_id,
-                                              port_id,
-                                              tenant_id,
-                                              reuse_after)
 
-        self.assertEqual(mac2['tenant_id'], tenant_id)
-        self.assertIsNone(mac2['created_at'])  # null pre-insert
-        self.assertEqual(mac2['address'], mar['first_address'] + 1)
-        self.assertEqual(mac2['mac_address_range_id'], mar['id'])
-        self.assertFalse(mac2['deallocated'])
-        self.assertIsNone(mac2['deallocated_at'])
+class QuarkNewIPAddressAllocation(QuarkIpamBaseTest):
+    @contextlib.contextmanager
+    def _stubs(self, addresses=None, subnets=None):
+        if not addresses:
+            addresses = [None]
+        db_mod = "quark.db.api"
+        with contextlib.nested(
+            mock.patch("%s.ip_address_find" % db_mod),
+            mock.patch("%s.subnet_find_allocation_counts" % db_mod)
+        ) as (addr_find, subnet_find):
+            addr_find.side_effect = addresses
+            subnet_find.return_value = subnets
+            yield
 
-    def test_allocate_mac_address_fully_allocated_range(self):
-        net_id = None
-        port_id = None
-        tenant_id = 'foobar'
-        reuse_after = 0
+    def test_allocate_new_ip_address_in_empty_range(self):
+        subnet = dict(id=1, first_ip=0, last_ip=255,
+                      cidr="0.0.0.0/24", ip_version=4)
+        with self._stubs(subnets=[(subnet, 0)], addresses=[None, None]):
+            address = self.ipam.allocate_ip_address(self.context, 0, 0, 0)
+            self.assertEqual(address["address"], 0)
 
-        self._create_and_insert_mar(mask=48)
-        mar = self.context.session.query(models.MacAddressRange).first()
+    def test_allocate_new_ip_in_partially_allocated_range(self):
+        addr = dict(id=1, address=0)
+        subnet = dict(id=1, first_ip=0, last_ip=255,
+                      cidr="0.0.0.0/24", ip_version=4)
+        with self._stubs(subnets=[(subnet, 0)], addresses=[None, addr]):
+            address = self.ipam.allocate_ip_address(self.context, 0, 0, 0)
+            self.assertEqual(address["address"], 1)
 
-        mac = models.MacAddress(tenant_id=tenant_id,
-                                address=mar['first_address'],
-                                mac_address_range_id=mar['id'],
-                                deallocated=False,
-                                deallocated_at=None)
-        self.context.session.add(mac)
-        self.context.session.flush()
+    def test_allocate_ip_one_full_one_open_subnet(self):
+        subnet1 = dict(id=1, first_ip=0, last_ip=0,
+                       cidr="0.0.0.0/32", ip_version=4)
+        subnet2 = dict(id=2, first_ip=2, last_ip=255,
+                       cidr="0.0.0.0/24", ip_version=4)
+        subnets = [(subnet1, 1), (subnet2, 0)]
+        with self._stubs(subnets=subnets, addresses=[None, None]):
+            address = self.ipam.allocate_ip_address(self.context, 0, 0, 0)
+            self.assertEqual(address["address"], 2)
+            self.assertEqual(address["subnet_id"], 2)
 
-        with self.assertRaises(exceptions.MacAddressGenerationFailure):
-            self.ipam.allocate_mac_address(self.context.session,
-                                           net_id,
-                                           port_id,
-                                           tenant_id,
-                                           reuse_after)
+    def test_allocate_ip_no_subnet_fails(self):
+        with self._stubs(subnets=[]):
+            with self.assertRaises(exceptions.IpAddressGenerationFailure):
+                self.ipam.allocate_ip_address(self.context, 0, 0, 0)
 
-    def test_allocate_mac_address_multiple_ranges(self):
-        '''Tests that new address is allocated in m.a.r. that has the most macs
-        allocated to it.'''
-        net_id = None
-        port_id = None
-        tenant_id = 'foobar'
-        reuse_after = 0
+    def test_allocate_ip_no_available_subnet_fails(self):
+        subnet1 = dict(id=1, first_ip=0, last_ip=0,
+                       cidr="0.0.0.0/32", ip_version=4)
+        with self._stubs(subnets=[(subnet1, 1)]):
+            with self.assertRaises(exceptions.IpAddressGenerationFailure):
+                self.ipam.allocate_ip_address(self.context, 0, 0, 0)
 
-        self._create_and_insert_mar()
-        mar = self.context.session.query(models.MacAddressRange).first()
+    def test_allocate_ip_two_open_subnets_choses_first(self):
+        subnet1 = dict(id=1, first_ip=0, last_ip=255,
+                       cidr="0.0.0.0/24", ip_version=4)
+        subnet2 = dict(id=2, first_ip=256, last_ip=510,
+                       cidr="0.0.1.0/24", ip_version=4)
+        subnets = [(subnet1, 1), (subnet2, 1)]
+        with self._stubs(subnets=subnets, addresses=[None, None]):
+            address = self.ipam.allocate_ip_address(self.context, 0, 0, 0)
+            self.assertEqual(address["address"], 0)
+            self.assertEqual(address["subnet_id"], 1)
 
-        mac = models.MacAddress(tenant_id=tenant_id,
-                                address=mar['first_address'],
-                                mac_address_range_id=mar['id'],
-                                deallocated=False,
-                                deallocated_at=None)
-        self.context.session.add(mac)
-        self.context.session.flush()
+    def test_find_requested_ip_subnet(self):
+        subnet1 = dict(id=1, first_ip=0, last_ip=255,
+                       cidr="0.0.0.0/24", ip_version=4)
+        subnets = [(subnet1, 1)]
+        with self._stubs(subnets=subnets, addresses=[None, None]):
+            address = self.ipam.allocate_ip_address(
+                self.context, 0, 0, 0, ip_address="0.0.0.240")
+            self.assertEqual(address["address"], 240)
+            self.assertEqual(address["subnet_id"], 1)
 
-        self._create_and_insert_mar(base='01:02:04:00:00:00')
+    def test_no_valid_subnet_for_requested_ip_fails(self):
+        subnet1 = dict(id=1, first_ip=0, last_ip=255,
+                       cidr="0.0.1.0/24", ip_version=4)
+        subnets = [(subnet1, 1)]
+        with self._stubs(subnets=subnets, addresses=[None, None]):
+            with self.assertRaises(exceptions.IpAddressGenerationFailure):
+                self.ipam.allocate_ip_address(
+                    self.context, 0, 0, 0, ip_address="0.0.0.240")
 
-        mac = self.ipam.allocate_mac_address(self.context.session,
-                                             net_id,
-                                             port_id,
-                                             tenant_id,
-                                             reuse_after)
 
-        self.assertEqual(mac['tenant_id'], tenant_id)
-        self.assertIsNone(mac['created_at'])  # null pre-insert
-        self.assertEqual(mac['address'], mar['first_address'] + 1)
-        self.assertEqual(mac['mac_address_range_id'], mar['id'])
-        self.assertFalse(mac['deallocated'])
-        self.assertIsNone(mac['deallocated_at'])
+class QuarkIPAddressAllocateDeallocated(QuarkIpamBaseTest):
+    @contextlib.contextmanager
+    def _stubs(self, ip_find=True):
+        subnet = dict(id=1, ip_version=4)
+        address = dict(id=1, address=0)
+        updated_address = address.copy()
 
-    def test_deallocate_mac_address_failure(self):
-        with self.assertRaises(exceptions.NotFound):
-            self.ipam.deallocate_mac_address(self.context.session,
-                                             '01:02:04:00:00:00')
+        db_mod = "quark.db.api"
+        with contextlib.nested(
+            mock.patch("%s.ip_address_find" % db_mod),
+            mock.patch("%s.ip_address_update" % db_mod),
+            mock.patch("quark.ipam.QuarkIpam._choose_available_subnet")
+        ) as (addr_find, addr_update, choose_subnet):
+            if ip_find:
+                addr_find.return_value = address
+            else:
+                updated_address["id"] = None
+                addr_find.side_effect = [None, updated_address]
+                addr_update.return_value = updated_address
+            choose_subnet.return_value = subnet
+            yield
 
-    def test_deallocate_mac_address_success(self):
-        tenant_id = 'foobar'
+    def test_allocate_finds_deallocated_ip_succeeds(self):
+        with self._stubs():
+            ipaddress = self.ipam.allocate_ip_address(self.context, 0, 0, 0)
+            self.assertIsNotNone(ipaddress['id'])
+            self.assertFalse(
+                quark.ipam.QuarkIpam._choose_available_subnet.called)
 
-        self._create_and_insert_mar()
-        mar = self.context.session.query(models.MacAddressRange).first()
-
-        mac = models.MacAddress(tenant_id=tenant_id,
-                                address=mar['first_address'],
-                                mac_address_range_id=mar['id'],
-                                deallocated=False,
-                                deallocated_at=None)
-        self.context.session.add(mac)
-        self.context.session.flush()
-
-        test_datetime = datetime(1970, 1, 1)
-        with mock.patch('quark.ipam.timeutils') as timeutils:
-            timeutils.utcnow.return_value = test_datetime
-            self.ipam.deallocate_mac_address(self.context.session,
-                                             mar['first_address'])
-
-        mac = self.context.session.query(models.MacAddress).first()
-        self.assertTrue(mac['deallocated'])
-        self.assertEqual(mac['deallocated_at'], test_datetime)
-
-    def _create_and_insert_net(self, name='mynet', tenant_id='foobar'):
-        net = models.Network()
-        net['name'] = name
-        net['tenant_id'] = tenant_id
-        self.context.session.add(net)
-        self.context.session.flush()
-
-    def _create_and_insert_subnet(self, net_id, tenant_id='foobar',
-                                  cidr='192.168.10.1/24'):
-        subnet = models.Subnet()
-        subnet['tenant_id'] = tenant_id
-        subnet['network_id'] = net_id
-        subnet['cidr'] = cidr
-        self.context.session.add(subnet)
-        self.context.session.flush()
-
-    def _create_and_insert_port(self, net_id, id='123', backend_key='123',
-                                device_id='123', tenant_id='foobar'):
-        port = models.Port()
-        port['tenant_id'] = tenant_id
-        port['id'] = id
-        port['network_id'] = net_id
-        port['backend_key'] = backend_key
-        port['mac_address'] = None
-        port['device_id'] = device_id
-        self.context.session.add(port)
-        self.context.session.flush()
-
-    def _create_and_insert_ip(self, ports, subnet_id, net_id,
-                              tenant_id='foobar',
-                              address='::ffff:192.168.10.0',
-                              deallocated=False, deallocated_at=None):
-        ipaddress = models.IPAddress()
-        ipaddress['tenant_id'] = tenant_id
-        ipaddress['address_readable'] = address
-        ipaddress['address'] = int(netaddr.IPAddress(address))
-        ipaddress['subnet_id'] = subnet_id
-        ipaddress['network_id'] = net_id
-        ipaddress['version'] = 4
-        ipaddress['deallocated'] = deallocated
-        ipaddress['deallocated_at'] = deallocated_at
-        if not deallocated:
-            for port in ports:
-                port['ip_addresses'].extend([ipaddress])
-        self.context.session.add(ipaddress)
-        self.context.session.flush()
-
-    def test_allocate_ip_address_deallocated_success(self):
-        tenant_id = 'foobar'
-        test_datetime = datetime(1970, 1, 1)
-        reuse_after = 0
-
-        self._create_and_insert_net()
-        net = self.context.session.query(models.Network).first()
-
-        self._create_and_insert_subnet(net['id'])
-        subnet = self.context.session.query(models.Subnet).first()
-
-        self._create_and_insert_port(net['id'])
-        port = self.context.session.query(models.Port).first()
-
-        self._create_and_insert_ip([port],
-                                   subnet['id'],
-                                   net['id'],
-                                   deallocated=True,
-                                   deallocated_at=test_datetime)
-
-        ipaddress = self.ipam.allocate_ip_address(self.context.session,
-                                                  net['id'],
-                                                  port['id'],
-                                                  tenant_id,
-                                                  reuse_after)
-
-        self.assertIsNotNone(ipaddress['id'])
-        self.assertEqual(ipaddress['tenant_id'], tenant_id)
-        self.assertEqual(ipaddress['address_readable'], '::ffff:192.168.10.0')
-        self.assertEqual(int(ipaddress['address']),
-                         int(netaddr.IPAddress('::ffff:192.168.10.0')))
-        self.assertEqual(ipaddress['subnet_id'], subnet['id'])
-        self.assertEqual(ipaddress['network_id'], net['id'])
-        self.assertEqual(ipaddress['version'], 4)
-        self.assertFalse(ipaddress['deallocated'])
-        self.assertIsNone(ipaddress['deallocated_at'])
-        self.assertEqual(len(ipaddress['ports']), 0)
-
-    def test_allocate_ip_address_deallocated_failure(self):
+    def test_allocate_finds_no_deallocated_creates_new_ip(self):
         '''Fails based on the choice of reuse_after argument. Allocates new ip
         address instead of previously deallocated mac address.'''
-        tenant_id = 'foobar'
-        test_datetime = datetime(1970, 1, 1)
-        reuse_after = 3600
-
-        self._create_and_insert_net()
-        net = self.context.session.query(models.Network).first()
-
-        self._create_and_insert_subnet(net['id'])
-        subnet = self.context.session.query(models.Subnet).first()
-
-        self._create_and_insert_port(net['id'])
-        port = self.context.session.query(models.Port).first()
-
-        self._create_and_insert_ip([port],
-                                   subnet['id'],
-                                   net['id'],
-                                   deallocated=True,
-                                   deallocated_at=test_datetime)
-
-        with mock.patch('quark.ipam.timeutils') as timeutils:
-            timeutils.utcnow.return_value = test_datetime
-            ipaddress = self.ipam.allocate_ip_address(self.context.session,
-                                                      net['id'],
-                                                      port['id'],
-                                                      tenant_id,
-                                                      reuse_after)
+        with self._stubs(ip_find=False):
+            ipaddress = self.ipam.allocate_ip_address(self.context, 0, 0, 0)
             self.assertIsNone(ipaddress['id'])
-            self.assertEqual(ipaddress['tenant_id'], tenant_id)
-            self.assertEqual(ipaddress['address_readable'],
-                             '::ffff:192.168.10.1')
-            self.assertEqual(ipaddress['address'],
-                             int(netaddr.IPAddress('::ffff:192.168.10.1')))
-            self.assertEqual(ipaddress['subnet_id'], subnet['id'])
-            self.assertEqual(ipaddress['network_id'], net['id'])
-            self.assertEqual(ipaddress['version'], 4)
-            self.assertFalse(ipaddress['deallocated'])
-            self.assertIsNone(ipaddress['deallocated_at'])
-            self.assertEqual(len(ipaddress['ports']), 0)
-
-    def test_allocate_ip_address_no_subnets_failure(self):
-        net_id = None
-        port_id = None
-        tenant_id = None
-        reuse_after = 0
-        with self.assertRaises(exceptions.IpAddressGenerationFailure):
-            self.ipam.allocate_ip_address(self.context.session,
-                                          net_id,
-                                          port_id,
-                                          tenant_id,
-                                          reuse_after)
-
-    def test_allocate_ip_address_fully_allocated_subnet(self):
-        tenant_id = 'foobar'
-        reuse_after = 0
-
-        self._create_and_insert_net()
-        net = self.context.session.query(models.Network).first()
-
-        self._create_and_insert_subnet(net['id'], cidr='192.168.10.1/32')
-        subnet = self.context.session.query(models.Subnet).first()
-
-        self._create_and_insert_port(net['id'])
-        port = self.context.session.query(models.Port).first()
-
-        self._create_and_insert_ip([port],
-                                   subnet['id'],
-                                   net['id'])
-
-        with self.assertRaises(exceptions.IpAddressGenerationFailure):
-            self.ipam.allocate_ip_address(self.context.session,
-                                          net['id'],
-                                          port['id'],
-                                          tenant_id,
-                                          reuse_after)
-
-    def test_allocate_ip_address_multiple_subnets(self):
-        tenant_id = 'foobar'
-        reuse_after = 0
-
-        self._create_and_insert_net()
-        net = self.context.session.query(models.Network).first()
-
-        self._create_and_insert_subnet(net['id'])
-        primary_subnet = self.context.session.query(models.Subnet).first()
-        self._create_and_insert_subnet(net['id'], cidr='192.168.20.1/24')
-
-        self._create_and_insert_port(net['id'])
-        port = self.context.session.query(models.Port).first()
-
-        self._create_and_insert_ip([port], primary_subnet['id'], net['id'])
-
-        ipaddress = self.ipam.allocate_ip_address(self.context.session,
-                                                  net['id'],
-                                                  port['id'],
-                                                  tenant_id,
-                                                  reuse_after)
-        self.assertIsNone(ipaddress['id'])
-        self.assertEqual(ipaddress['tenant_id'], tenant_id)
-        self.assertEqual(ipaddress['address_readable'], '::ffff:192.168.10.1')
-        self.assertEqual(ipaddress['address'],
-                         int(netaddr.IPAddress('::ffff:192.168.10.1')))
-        self.assertEqual(ipaddress['subnet_id'], primary_subnet['id'])
-        self.assertEqual(ipaddress['network_id'], net['id'])
-        self.assertEqual(ipaddress['version'], 4)
-        self.assertFalse(ipaddress['deallocated'])
-        self.assertIsNone(ipaddress['deallocated_at'])
-        self.assertEqual(len(ipaddress['ports']), 0)
-
-    def test_allocate_ip_address_multiple_networks_subnet(self):
-        tenant_id = 'foobar'
-        reuse_after = 0
-
-        self._create_and_insert_net(name='mynet')
-        self._create_and_insert_net(name='mynet2')
-        primary_net = self.context.session.query(models.Network).first()
-
-        self._create_and_insert_subnet(primary_net['id'])
-        subnet = self.context.session.query(models.Subnet).first()
-
-        self._create_and_insert_port(primary_net['id'])
-        port = self.context.session.query(models.Port).first()
-
-        ipaddress = self.ipam.allocate_ip_address(self.context.session,
-                                                  primary_net['id'],
-                                                  port['id'],
-                                                  tenant_id,
-                                                  reuse_after)
-        self.assertIsNone(ipaddress['id'])
-        self.assertEqual(ipaddress['tenant_id'], tenant_id)
-        self.assertEqual(ipaddress['address_readable'], '::ffff:192.168.10.0')
-        self.assertEqual(ipaddress['address'],
-                         int(netaddr.IPAddress('::ffff:192.168.10.0')))
-        self.assertEqual(ipaddress['subnet_id'], subnet['id'])
-        self.assertEqual(ipaddress['network_id'], primary_net['id'])
-        self.assertEqual(ipaddress['version'], 4)
-        self.assertFalse(ipaddress['deallocated'])
-        self.assertIsNone(ipaddress['deallocated_at'])
-        self.assertEqual(len(ipaddress['ports']), 0)
-
-    def test_allocate_ip_address_multiple_networks_deallocated(self):
-        tenant_id = 'foobar'
-        test_datetime = datetime(1970, 1, 1)
-        reuse_after = 0
-
-        self._create_and_insert_net(name='mynet')
-        self._create_and_insert_net(name='mynet2')
-        primary_net = self.context.session.query(models.Network).first()
-
-        self._create_and_insert_subnet(primary_net['id'])
-        subnet = self.context.session.query(models.Subnet).first()
-
-        self._create_and_insert_port(primary_net['id'])
-        port = self.context.session.query(models.Port).first()
-
-        self._create_and_insert_ip([port],
-                                   subnet['id'],
-                                   primary_net['id'],
-                                   deallocated=True,
-                                   deallocated_at=test_datetime)
-
-        ipaddress = self.ipam.allocate_ip_address(self.context.session,
-                                                  primary_net['id'],
-                                                  port['id'],
-                                                  tenant_id,
-                                                  reuse_after)
-        self.assertIsNotNone(ipaddress['id'])
-        self.assertEqual(ipaddress['tenant_id'], tenant_id)
-        self.assertEqual(ipaddress['address_readable'], '::ffff:192.168.10.0')
-        self.assertEqual(int(ipaddress['address']),
-                         int(netaddr.IPAddress('::ffff:192.168.10.0')))
-        self.assertEqual(ipaddress['subnet_id'], subnet['id'])
-        self.assertEqual(ipaddress['network_id'], primary_net['id'])
-        self.assertEqual(ipaddress['version'], 4)
-        self.assertFalse(ipaddress['deallocated'])
-        self.assertIsNone(ipaddress['deallocated_at'])
-        self.assertEqual(len(ipaddress['ports']), 0)
-
-    def test_allocate_ip_address_success(self):
-        tenant_id = 'foobar'
-        reuse_after = 0
-
-        self._create_and_insert_net()
-        net = self.context.session.query(models.Network).first()
-
-        self._create_and_insert_subnet(net['id'])
-        subnet = self.context.session.query(models.Subnet).first()
-
-        self._create_and_insert_port(net['id'])
-        port = self.context.session.query(models.Port).first()
-
-        ipaddress = self.ipam.allocate_ip_address(self.context.session,
-                                                  net['id'],
-                                                  port['id'],
-                                                  tenant_id,
-                                                  reuse_after)
-        self.assertIsNone(ipaddress['id'])
-        self.assertEqual(ipaddress['tenant_id'], tenant_id)
-        self.assertEqual(ipaddress['address_readable'], '::ffff:192.168.10.0')
-        self.assertEqual(ipaddress['address'],
-                         int(netaddr.IPAddress('::ffff:192.168.10.0')))
-        self.assertEqual(ipaddress['subnet_id'], subnet['id'])
-        self.assertEqual(ipaddress['network_id'], net['id'])
-        self.assertEqual(ipaddress['version'], 4)
-        self.assertFalse(ipaddress['deallocated'])
-        self.assertIsNone(ipaddress['deallocated_at'])
-        self.assertEqual(len(ipaddress['ports']), 0)
-
-    def test_allocate_ip_address_multiple_ips(self):
-        tenant_id = 'foobar'
-        reuse_after = 0
-
-        self._create_and_insert_net()
-        net = self.context.session.query(models.Network).first()
-
-        self._create_and_insert_subnet(net['id'])
-        subnet = self.context.session.query(models.Subnet).first()
-
-        self._create_and_insert_port(net['id'])
-        port = self.context.session.query(models.Port).first()
-
-        ipaddress = self.ipam.allocate_ip_address(self.context.session,
-                                                  net['id'],
-                                                  port['id'],
-                                                  tenant_id,
-                                                  reuse_after)
-        self.assertIsNone(ipaddress['id'])
-        self.assertEqual(ipaddress['tenant_id'], tenant_id)
-        self.assertEqual(ipaddress['address_readable'], '::ffff:192.168.10.0')
-        self.assertEqual(ipaddress['address'],
-                         int(netaddr.IPAddress('::ffff:192.168.10.0')))
-        self.assertEqual(ipaddress['subnet_id'], subnet['id'])
-        self.assertEqual(ipaddress['network_id'], net['id'])
-        self.assertEqual(ipaddress['version'], 4)
-        self.assertFalse(ipaddress['deallocated'])
-        self.assertIsNone(ipaddress['deallocated_at'])
-        self.assertEqual(len(ipaddress['ports']), 0)
-        self.context.session.add(ipaddress)
-        self.context.session.flush()
-
-        ipaddress2 = self.ipam.allocate_ip_address(self.context.session,
-                                                   net['id'],
-                                                   port['id'],
-                                                   tenant_id,
-                                                   reuse_after)
-        self.assertIsNone(ipaddress2['id'])
-        self.assertEqual(ipaddress2['tenant_id'], tenant_id)
-        self.assertEqual(ipaddress2['address_readable'], '::ffff:192.168.10.1')
-        self.assertEqual(ipaddress2['address'],
-                         int(netaddr.IPAddress('::ffff:192.168.10.1')))
-        self.assertEqual(ipaddress2['subnet_id'], subnet['id'])
-        self.assertEqual(ipaddress2['network_id'], net['id'])
-        self.assertEqual(ipaddress2['version'], 4)
-        self.assertFalse(ipaddress2['deallocated'])
-        self.assertIsNone(ipaddress2['deallocated_at'])
-        self.assertEqual(len(ipaddress['ports']), 0)
-
-    def test_deallocate_ip_address_success_one_port(self):
-        self._create_and_insert_net()
-        net = self.context.session.query(models.Network).first()
-
-        self._create_and_insert_subnet(net['id'])
-        subnet = self.context.session.query(models.Subnet).first()
-
-        self._create_and_insert_port(net['id'])
-        port = self.context.session.query(models.Port).first()
-
-        self._create_and_insert_ip([port], subnet['id'], net['id'])
-
-        self.ipam.deallocate_ip_address(self.context.session,
-                                        port['id'])
-        self.context.session.flush()
-
-        ipaddress = self.context.session.query(models.IPAddress).first()
-        self.assertTrue(ipaddress['deallocated'])
-        self.assertEqual(len(ipaddress['ports']), 0)
-
-    def test_deallocate_ip_address_success_two_ports(self):
-        self._create_and_insert_net()
-        net = self.context.session.query(models.Network).first()
-
-        self._create_and_insert_subnet(net['id'])
-        subnet = self.context.session.query(models.Subnet).first()
-
-        self._create_and_insert_port(net['id'], id='123')
-        self._create_and_insert_port(net['id'], id='456')
-        ports = self.context.session.query(models.Port).all()
-
-        self._create_and_insert_ip(ports, subnet['id'], net['id'])
-
-        self.ipam.deallocate_ip_address(self.context.session,
-                                        ports[0]['id'])
-        self.context.session.flush()
-
-        ipaddress = self.context.session.query(models.IPAddress).first()
-        self.assertFalse(ipaddress['deallocated'])
-        self.assertIsNotNone(ipaddress['ports'])
-
-    def test_deallocate_ip_address_failure(self):
-        port_id = 'abc'
-        with self.assertRaises(exceptions.NotFound):
-            self.ipam.deallocate_ip_address(self.context.session,
-                                            port_id)
+            self.assertTrue(
+                quark.ipam.QuarkIpam._choose_available_subnet.called)


### PR DESCRIPTION
Adds a new DB API layer can easily be mocked out for No DB testing of
the components of Quark. Also refactors the IPAM tests to utilize the
new API.
