### PR TITLE
Fixes a bug in route creation

### DIFF
--- a/quark/db/api.py
+++ b/quark/db/api.py
@@ -302,6 +302,7 @@ def route_create(context, **route_dict):
     new_route.update(route_dict)
     new_route["tenant_id"] = context.tenant_id
     context.session.add(new_route)
+    return new_route
 
 
 def route_delete(context, route):

--- a/quark/plugin.py
+++ b/quark/plugin.py
@@ -666,7 +666,7 @@ class Plugin(quantum_plugin_base_v2.QuantumPluginBaseV2):
         LOG.info("create_route for tenant %s" % context.tenant_id)
         route = route["route"]
         subnet_id = route["subnet_id"]
-        subnet = db_api.subnet_find(context, id)
+        subnet = db_api.subnet_find(context, id=id)
         if not subnet:
             raise exceptions.SubnetNotFound(subnet_id=subnet_id)
 


### PR DESCRIPTION
The subnet_find in the route creation wasn't being passed the keyword
args properly, and the route_create method wasn't returning the newly
instantiated route model.
