### PR TITLE
Fix for circular reference error

### DIFF
--- a/quark/plugin.py
+++ b/quark/plugin.py
@@ -215,6 +215,12 @@ class Plugin(quantum_plugin_base_v2.QuantumPluginBaseV2):
         if not net:
             raise exceptions.NetworkNotFound(net_id=net_id)
 
+        # TODO(mdietz): do something clever with these
+        garbage = ["allocation_pools", "dns_nameservers"]
+        for k in garbage:
+            if k in subnet["subnet"]:
+                subnet["subnet"].pop(k)
+
         new_subnet = db_api.subnet_create(context, **subnet["subnet"])
         subnet_dict = self._make_subnet_dict(new_subnet)
         return subnet_dict


### PR DESCRIPTION
On create_subnet, the quantum client passes in arguments to create a subnet
with, including dns_nameservers and allocation_pools, which do not exist in
quark's database models. SQLAlchemy causes these fields to exist in the
model created and result as basic objects in the response object, which in turn
is choked upon by oslo-incubator's jsonutils.to_primitive function.
