### PR TITLE
Implemented additional subnet attributes

### DIFF
--- a/quark/api/extensions/subnets_quark.py
+++ b/quark/api/extensions/subnets_quark.py
@@ -1,0 +1,65 @@
+# vim: tabstop=4 shiftwidth=4 softtabstop=4
+
+# Copyright (c) 2013 OpenStack Foundation.
+# All rights reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+from quantum.api import extensions
+from quantum.api.v2 import attributes
+
+EXTENDED_ATTRIBUTES_2_0 = {
+    'subnets': {
+        "allocation_pools": {'allow_post': False, 'allow_put': False,
+                             'default': attributes.ATTR_NOT_SPECIFIED,
+                             'is_visible': False},
+        "enable_dhcp": {'allow_post': False, 'allow_put': False,
+                        'default': False,
+                        'is_visible': True},
+    }
+}
+
+
+class Subnets_quark(extensions.ExtensionDescriptor):
+    """Extends subnets for quark API purposes.
+
+    * Shunts enable_dhcp to false
+    * Disables allocation_pools
+    """
+
+    @classmethod
+    def get_name(cls):
+        return "Quark Subnets API Extension"
+
+    @classmethod
+    def get_alias(cls):
+        return "subnets_quark"
+
+    @classmethod
+    def get_description(cls):
+        return "Quark Subnets API Extension"
+
+    @classmethod
+    def get_namespace(cls):
+        return ("http://docs.openstack.org/api/openstack-network/2.0/content/"
+                "Subnets.html")
+
+    @classmethod
+    def get_updated(cls):
+        return "2013-04-22T10:00:00-00:00"
+
+    def get_extended_resources(self, version):
+        if version == "2.0":
+            return EXTENDED_ATTRIBUTES_2_0
+        else:
+            return {}

--- a/quark/db/api.py
+++ b/quark/db/api.py
@@ -88,6 +88,10 @@ def _model_query(context, model, filters, query, fields=None):
     if filters.get("mac_address_range_id"):
         query = query.filter(model.mac_address_range_id ==
                              filters["mac_address_range_id"])
+
+    if filters.get("cidr"):
+        query = query.filter(model.cidr == filters["cidr"])
+
     return query
 
 
@@ -292,6 +296,12 @@ def subnet_create(context, **subnet_dict):
     return subnet
 
 
+def subnet_update(context, subnet, **kwargs):
+    subnet.update(kwargs)
+    context.session.add(subnet)
+    return subnet
+
+
 @scoped
 def route_find(context, fields=None, **filters):
     query = context.session.query(models.Route)
@@ -307,5 +317,25 @@ def route_create(context, **route_dict):
     return new_route
 
 
+def route_update(context, route, **kwargs):
+    route.update(kwargs)
+    context.session.add(route)
+    return route
+
+
 def route_delete(context, route):
     context.session.delete(route)
+
+
+def dns_create(context, **dns_dict):
+    dns_nameserver = models.DNSNameserver()
+    ip = dns_dict.pop("ip")
+    dns_nameserver.update(dns_dict)
+    dns_nameserver["ip"] = int(ip)
+    dns_nameserver["tenant_id"] = context.tenant_id
+    context.session.add(dns_nameserver)
+    return dns_nameserver
+
+
+def dns_delete(context, dns):
+    context.session.delete(dns)

--- a/quark/db/models.py
+++ b/quark/db/models.py
@@ -162,6 +162,12 @@ class Route(BASEV2, models.HasTenant, models.HasId, IsHazTags):
     subnet_id = sa.Column(sa.String(36), sa.ForeignKey("quark_subnets.id"))
 
 
+class DNSNameserver(BASEV2, models.HasTenant, models.HasId, IsHazTags):
+    __tablename__ = "quark_dns_nameservers"
+    ip = sa.Column(custom_types.INET())
+    subnet_id = sa.Column(sa.String(36), sa.ForeignKey("quark_subnets.id"))
+
+
 class Subnet(BASEV2, models.HasId, models.HasTenant, IsHazTags):
     """Upstream model for IPs.
 
@@ -177,6 +183,7 @@ class Subnet(BASEV2, models.HasId, models.HasTenant, IsHazTags):
     for your subnet
     """
     __tablename__ = "quark_subnets"
+    name = sa.Column(sa.String(255))
     network_id = sa.Column(sa.String(36), sa.ForeignKey('quark_networks.id'))
     _cidr = sa.Column(sa.String(64), nullable=False)
 
@@ -210,6 +217,12 @@ class Subnet(BASEV2, models.HasId, models.HasTenant, IsHazTags):
                                      backref="subnet")
     routes = orm.relationship(Route, primaryjoin="Route.subnet_id==Subnet.id",
                               backref='subnet', cascade='delete')
+    enable_dhcp = sa.Column(sa.Boolean(), default=False)
+    dns_nameservers = orm.relationship(
+        DNSNameserver,
+        primaryjoin="DNSNameserver.subnet_id==Subnet.id",
+        backref='subnet',
+        cascade='delete')
 
 
 port_ip_association_table = sa.Table(


### PR DESCRIPTION
This change implements name, dns_nameservers, gateway_ip, host_routes subnet
attributes. Also, disables allocation_pools and enable_dhcp subnet attributes.
-    Modified Subnet model, added DNSNameserver model (WARNING: DB changes!)
  -    Added name, enable_dhcp, and dns_nameservers to Subnet model
  -    Added subnet_update, route_update, dns_create, dns_delete
-    Implemented api extension to disable allocation_pools and enable_dhcp
-    Implemented gateway_ip, dns_nameservers, host_routes for create_subnet
-    Implemented gateway_ip, dns_nameservers, host_routes for update_subnet
-    Fixed broken subnet-related tests
-    Implemented update_subnet tests
-    Implemented create_subnet tests
-    Integration tested with quantum+quark+sqlite
