### PR TITLE
Centralize context creation

### DIFF
--- a/quark/tests/test_base.py
+++ b/quark/tests/test_base.py
@@ -15,7 +15,12 @@
 
 import unittest2
 
+from quantum import context
+
 
 class TestBase(unittest2.TestCase):
     '''Class to decide which unit test class to inherit from uniformly.'''
-    pass
+
+    def setUp(self):
+        super(TestBase, self).setUp()
+        self.context = context.Context('fake', 'fake', is_admin=False)

--- a/quark/tests/test_db_api.py
+++ b/quark/tests/test_db_api.py
@@ -15,7 +15,6 @@
 
 import mock
 from oslo.config import cfg
-from quantum import context
 from quantum.db import api as quantum_db_api
 
 from quark.db import api as db_api
@@ -27,10 +26,11 @@ from sqlalchemy.orm import configure_mappers
 
 class TestDBAPI(test_base.TestBase):
     def setUp(self):
+        super(TestDBAPI, self).setUp()
+
         cfg.CONF.set_override('sql_connection', 'sqlite://', 'DATABASE')
         quantum_db_api.configure_db()
         configure_mappers()
-        self.context = context.get_admin_context()
 
     def test_port_find_ip_address_id(self):
         self.context.session.query = mock.Mock()

--- a/quark/tests/test_ipam.py
+++ b/quark/tests/test_ipam.py
@@ -17,7 +17,6 @@ import contextlib
 import mock
 from oslo.config import cfg
 from quantum.common import exceptions
-from quantum import context
 from quantum.db import api as quantum_db_api
 
 from quark.db import models
@@ -28,11 +27,12 @@ from quark.tests import test_base
 
 class QuarkIpamBaseTest(test_base.TestBase):
     def setUp(self):
+        super(QuarkIpamBaseTest, self).setUp()
+
         cfg.CONF.set_override('sql_connection', 'sqlite://', 'DATABASE')
         quantum_db_api.configure_db()
         models.BASEV2.metadata.create_all(quantum_db_api._ENGINE)
         self.ipam = quark.ipam.QuarkIpam()
-        self.context = context.get_admin_context()
 
     def tearDown(self):
         quantum_db_api.clear_db()

--- a/quark/tests/test_nvp_driver.py
+++ b/quark/tests/test_nvp_driver.py
@@ -17,7 +17,6 @@ import contextlib
 import mock
 
 from oslo.config import cfg
-from quantum import context
 from quantum.db import api as db_api
 
 from quark.db import models
@@ -27,13 +26,16 @@ from quark.tests import test_base
 
 class TestNVPDriver(test_base.TestBase):
     def setUp(self):
+        super(TestNVPDriver, self).setUp()
+
         if not hasattr(self, 'driver'):
             self.driver = quark.drivers.nvp_driver.NVPDriver()
+
         cfg.CONF.set_override('sql_connection', 'sqlite://', 'DATABASE')
         self.driver.max_ports_per_switch = 0
         db_api.configure_db()
         models.BASEV2.metadata.create_all(db_api._ENGINE)
-        self.context = context.get_admin_context()
+
         self.lswitch_uuid = "12345678-1234-1234-1234-123456781234"
         self.context.tenant_id = "tid"
         self.lport_uuid = "12345678-0000-0000-0000-123456781234"

--- a/quark/tests/test_quark_plugin.py
+++ b/quark/tests/test_quark_plugin.py
@@ -55,8 +55,6 @@ class TestQuarkAPIExtensions(TestQuarkPlugin):
         quark.plugin.append_quark_extensions({})
 
     def test_append_no_extension_path(self):
-        opts = [cfg.StrOpt("api_extensions_path")]
-        quark.plugin.CONF.register_opts(opts)
         quark.plugin.append_quark_extensions(quark.plugin.CONF)
 
 

--- a/quark/tests/test_quark_plugin.py
+++ b/quark/tests/test_quark_plugin.py
@@ -20,7 +20,6 @@ import mock
 import netaddr
 from oslo.config import cfg
 from quantum.common import exceptions
-from quantum import context
 from quantum.db import api as db_api
 
 from quark.db import api as quark_db_api
@@ -33,9 +32,10 @@ from quark.tests import test_base
 
 class TestQuarkPlugin(test_base.TestBase):
     def setUp(self):
+        super(TestQuarkPlugin, self).setUp()
+
         cfg.CONF.set_override('sql_connection', 'sqlite://', 'DATABASE')
         db_api.configure_db()
-        self.context = context.get_admin_context()
         self.plugin = quark.plugin.Plugin()
 
     def tearDown(self):


### PR DESCRIPTION
Upstream quantum added policy checks into the context **init**. This
causes context creation to require policy.json when creating an admin
context. Move all the context creation into the base class and specify
not having an admin context by default.
