### PR TITLE
Implemented plugin.create_port: fixed_ip and mac_address

### DIFF
--- a/quark/db/api.py
+++ b/quark/db/api.py
@@ -187,13 +187,16 @@ def mac_address_find(context, **filters):
     return query
 
 
-def mac_address_range_find_allocation_counts(context):
+def mac_address_range_find_allocation_counts(context, address=None):
     query = context.session.query(models.MacAddressRange,
                                   sql_func.count(models.MacAddress.address).
-                                  label("count")).\
-        outerjoin(models.MacAddress).\
-        group_by(models.MacAddressRange).\
-        order_by("count DESC")
+                                  label("count"))
+    query = query.outerjoin(models.MacAddress)
+    query = query.group_by(models.MacAddressRange)
+    query = query.order_by("count DESC")
+    if address:
+        query = query.filter(models.MacAddressRange.last_address >= address)
+        query = query.filter(models.MacAddressRange.first_address <= address)
     return query
 
 

--- a/quark/db/models.py
+++ b/quark/db/models.py
@@ -274,6 +274,7 @@ class MacAddressRange(BASEV2, models.HasId):
     cidr = sa.Column(sa.String(255), nullable=False)
     first_address = sa.Column(sa.BigInteger(), nullable=False)
     last_address = sa.Column(sa.BigInteger(), nullable=False)
+    next_auto_assign_mac = sa.Column(sa.BigInteger(), nullable=False)
 
 
 class Network(BASEV2, models.HasTenant, models.HasId):


### PR DESCRIPTION
Implemented create_port with fixed_ip attribute
Implemented tests for create_port with fixed_ip attribute
Implemented create_port with mac_address attribute
Test fixes on allocate_mac_address ipam tests
Implemented tests for create_port with mac_address attribute
