### PR TITLE
Fixes port_create and ip policy bugs

### DIFF
--- a/quark/db/api.py
+++ b/quark/db/api.py
@@ -116,6 +116,8 @@ def scoped(f):
         _listify(kwargs)
 
         res = f(*args, **kwargs)
+        if not res:
+            return
         if "order_by" in kwargs:
             res = res.order_by(kwargs["order_by"])
 

--- a/quark/ipam.py
+++ b/quark/ipam.py
@@ -123,10 +123,18 @@ class QuarkIpam(object):
 
         # TODO(mdietz): this is a hack until we have IP policies
         ip_int = int(next_ip)
-        diff = ip_int - subnet["first_ip"]
+        first_ip = netaddr.IPAddress(int(subnet["first_ip"]))
+        last_ip = netaddr.IPAddress(int(subnet["last_ip"]))
+        if subnet["ip_version"] == 4:
+            first_ip = first_ip.ipv4()
+            last_ip = last_ip.ipv4()
+        first_ip = int(first_ip)
+        last_ip = int(last_ip)
+
+        diff = ip_int - first_ip
         if diff < 2:
             next_ip = netaddr.IPAddress(ip_int + (2 - diff))
-        if ip_int == subnet["last_ip"]:
+        if ip_int == last_ip:
             raise exceptions.IpAddressGenerationFailure(net_id=net_id)
         if next_ip not in netaddr.IPNetwork(subnet["cidr"]):
             raise exceptions.IpAddressGenerationFailure(net_id=net_id)


### PR DESCRIPTION
The default net strategies introduced a logic error that forgot to allow
for checking of the existence of a tenant owned network. Additionally,
the IP policy check was failing to account for the v4 of v6-ishness of
the subnet in question.
