### PR TITLE
network, subnet cleanup

### DIFF
--- a/quark/plugin.py
+++ b/quark/plugin.py
@@ -27,6 +27,7 @@ from sqlalchemy import event
 from zope import sqlalchemy as zsa
 
 from quantum.api.v2 import attributes
+from quantum.common import config as quantum_cfg
 from quantum.common import exceptions
 from quantum.db import api as quantum_db_api
 from quantum.extensions import securitygroup as sg_ext
@@ -130,7 +131,7 @@ class Plugin(quantum_plugin_base_v2.QuantumPluginBaseV2,
         res = {'id': network["id"],
                'name': network.get('name'),
                'tenant_id': network.get('tenant_id'),
-               'admin_state_up': network.get('admin_state_up'),
+               'admin_state_up': None,
                'status': network.get('status'),
                'shared': shared_net,
                #TODO(mdietz): this is the expected return. Then the client
@@ -153,7 +154,7 @@ class Plugin(quantum_plugin_base_v2.QuantumPluginBaseV2,
                "allocation_pools": [],
                "dns_nameservers": dns_nameservers or [],
                "cidr": subnet.get('cidr'),
-               "enable_dhcp": subnet.get('enable_dhcp')}
+               "enable_dhcp": None}
 
         def _host_route(route):
             return {"destination": route["cidr"],
@@ -261,7 +262,7 @@ class Plugin(quantum_plugin_base_v2.QuantumPluginBaseV2,
 
         """
         new_subnet_ipset = netaddr.IPSet([new_subnet_cidr])
-        if CONF.allow_overlapping_ips:
+        if quantum_cfg.cfg.CONF.allow_overlapping_ips:
             subnet_list = network.subnets
         else:
             subnet_list = db_api.subnet_find(context.elevated())
@@ -295,7 +296,7 @@ class Plugin(quantum_plugin_base_v2.QuantumPluginBaseV2,
         LOG.info("create_subnet for tenant %s" % context.tenant_id)
         net_id = subnet["subnet"]["network_id"]
 
-        net = db_api.network_find(context, net_id, scope=db_api.ONE)
+        net = db_api.network_find(context, id=net_id, scope=db_api.ONE)
         if not net:
             raise exceptions.NetworkNotFound(net_id=net_id)
 

--- a/quark/tests/test_quark_plugin.py
+++ b/quark/tests/test_quark_plugin.py
@@ -110,7 +110,7 @@ class TestQuarkGetSubnets(TestQuarkPlugin):
                       tenant_id=self.context.tenant_id, ip_version=4,
                       cidr="192.168.0.0/24", gateway_ip="192.168.0.1",
                       allocation_pools=[], dns_nameservers=[],
-                      enable_dhcp=True)
+                      enable_dhcp=None)
         expected_route = dict(destination=route["cidr"],
                               nexthop=route["gateway"])
 
@@ -140,7 +140,7 @@ class TestQuarkGetSubnets(TestQuarkPlugin):
                       tenant_id=self.context.tenant_id, ip_version=4,
                       cidr="192.168.0.0/24", gateway_ip="192.168.0.1",
                       allocation_pools=[], dns_nameservers=[],
-                      enable_dhcp=True)
+                      enable_dhcp=None)
 
         with self._stubs(subnets=subnet, routes=[route]):
             res = self.plugin.get_subnet(self.context, subnet_id)
@@ -847,23 +847,19 @@ class TestQuarkCreateNetwork(TestQuarkPlugin):
             yield net_create
 
     def test_create_network(self):
-        net = dict(id=1, name="public")
+        net = dict(id=1, name="public", admin_state_up=True,
+                   tenant_id=0)
         with self._stubs(net=net) as net_create:
             net = self.plugin.create_network(self.context, dict(network=net))
             self.assertTrue(net_create.called)
-
-    def test_create_network_with_subnets(self):
-        net = dict(id=1, name="public")
-        subnet = dict(subnet=dict(id=1, network_id=net["id"],
-                      tenant_id=self.context.tenant_id))
-        with self._stubs(net=net, subnet=subnet["subnet"]) as net_create:
-            net_dict = dict(network=net.copy())
-            net_dict["network"]["subnets"] = [subnet]
-            res = self.plugin.create_network(self.context, net_dict)
-            self.assertTrue(net_create.called)
-            self.assertEqual(res["id"], net["id"])
-            self.assertEqual(res["name"], net["name"])
-            self.assertEqual(res["subnets"][0], net["id"])
+            self.assertEqual(len(net.keys()), 7)
+            self.assertIsNotNone(net["id"])
+            self.assertEqual(net["name"], "public")
+            self.assertIsNone(net["admin_state_up"])
+            self.assertIsNone(net["status"])
+            self.assertEqual(net["subnets"], [])
+            self.assertEqual(net["shared"], False)
+            self.assertEqual(net["tenant_id"], 0)
 
 
 class TestIpAddresses(TestQuarkPlugin):


### PR DESCRIPTION
- network response with admin_state_up as None
- subnet response with enable_dhcp as None
- bugfix: load allow_overlapping_ips from quantum config
- bugfix: on create_subnet, specify id as named argument for network_find
- elaborate create_subnet test
