### PR TITLE
Bugfix: deallocate_ip_address in-loop deletion

### DIFF
--- a/quark/ipam.py
+++ b/quark/ipam.py
@@ -147,13 +147,11 @@ class QuarkIpam(object):
         return address
 
     def deallocate_ip_address(self, context, port, **kwargs):
-        for address in port["ip_addresses"]:
-            # Only disassociate from port, don't automatically deallocate
-            address["ports"].remove(port)
-            if len(address["ports"]) > 0:
-                continue
-
-            address["deallocated"] = 1
+        for addr in port["ip_addresses"]:
+            # Note: only deallocate ip if this is the only port mapped to it
+            if len(addr["ports"]) == 1:
+                addr["deallocated"] = 1
+        port["ip_addresses"] = []
 
     def deallocate_mac_address(self, context, address):
         mac = db_api.mac_address_find(context, address=address,

--- a/quark/tests/test_ipam.py
+++ b/quark/tests/test_ipam.py
@@ -176,17 +176,20 @@ class QuarkIPAddressDeallocation(QuarkIpamBaseTest):
         addr = dict(ports=[port])
         port["ip_addresses"].append(addr)
         self.ipam.deallocate_ip_address(self.context, port)
-        self.assertEqual(len(addr["ports"]), 0)
-        self.assertEqual(addr["deallocated"], True)
+        # ORM takes care of other model if one model is modified
+        self.assertTrue(len(addr["ports"]) == 0 or
+                        len(port["ip_addresses"]) == 0)
+        self.assertTrue(addr["deallocated"])
 
     def test_deallocate_ip_address_multiple_ports_no_deallocation(self):
         port = dict(ip_addresses=[])
         addr = dict(ports=[port, 2], deallocated=False)
         port["ip_addresses"].append(addr)
-
         self.ipam.deallocate_ip_address(self.context, port)
-        self.assertEqual(len(addr["ports"]), 1)
-        self.assertEqual(addr["deallocated"], False)
+        # ORM takes care of other model if one model is modified
+        self.assertTrue(len(addr["ports"]) == 1 or
+                        len(port["ip_addresses"]) == 0)
+        self.assertFalse(addr["deallocated"])
 
 
 class QuarkNewIPAddressAllocation(QuarkIpamBaseTest):


### PR DESCRIPTION
- Refactored deallocate_ip_address such that list traversal was separate
  from deleting elements from the list.
- Updated tests.

I thought of adding a regression test, but I wasn't sure how to mock out the ORM appropriately. For now, there is a test in krauq.
