### PR TITLE
Implemented IP Policies

### DIFF
--- a/quark/api/extensions/ip_policies.py
+++ b/quark/api/extensions/ip_policies.py
@@ -1,0 +1,96 @@
+# Copyright (c) 2013 OpenStack Foundation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from neutron.api import extensions
+from neutron import manager
+from neutron.openstack.common import log as logging
+from neutron import wsgi
+
+RESOURCE_NAME = "ip_policy"
+RESOURCE_COLLECTION = "ip_policies"
+EXTENDED_ATTRIBUTES_2_0 = {
+    RESOURCE_COLLECTION: {}
+}
+
+attr_dict = EXTENDED_ATTRIBUTES_2_0[RESOURCE_COLLECTION]
+attr_dict[RESOURCE_NAME] = {'allow_post': True,
+                            'allow_put': False,
+                            'is_visible': True}
+
+LOG = logging.getLogger("neutron.quark.api.extensions.ip_policies")
+
+
+class IPPoliciesController(wsgi.Controller):
+    def __init__(self, plugin):
+        self._resource_name = RESOURCE_NAME
+        self._plugin = plugin
+
+    def create(self, request, body=None):
+        body = self._deserialize(request.body, request.get_content_type())
+        return {RESOURCE_NAME:
+                self._plugin.create_ip_policy(request.context, body)}
+
+    def index(self, request):
+        context = request.context
+        return {RESOURCE_COLLECTION:
+                self._plugin.get_ip_policies(context)}
+
+    def show(self, request, id):
+        context = request.context
+        return {RESOURCE_NAME:
+                self._plugin.get_ip_policy(context, id)}
+
+    def delete(self, request, id, **kwargs):
+        context = request.context
+        return self._plugin.delete_ip_policy(context, id)
+
+
+class Ip_policies(object):
+    """IP Policies support."""
+    @classmethod
+    def get_name(cls):
+        return "IP Policies for a Neutron deployment"
+
+    @classmethod
+    def get_alias(cls):
+        return RESOURCE_COLLECTION
+
+    @classmethod
+    def get_description(cls):
+        return ("Expose functions for cloud admin to manage IP Policies"
+                "for each tenant")
+
+    @classmethod
+    def get_namespace(cls):
+        return ("http://docs.openstack.org/network/ext/"
+                "ip-policies/api/v2.0")
+
+    @classmethod
+    def get_updated(cls):
+        return "2013-06-19T10:00:00-00:00"
+
+    def get_extended_resources(self, version):
+        if version == "2.0":
+            return EXTENDED_ATTRIBUTES_2_0
+        else:
+            return {}
+
+    @classmethod
+    def get_resources(cls):
+        """Returns Ext Resources."""
+        plugin = manager.NeutronManager.get_plugin()
+        controller = IPPoliciesController(plugin)
+        return [extensions.ResourceExtension(Ip_policies.get_alias(),
+                                             controller)]

--- a/quark/db/api.py
+++ b/quark/db/api.py
@@ -252,7 +252,6 @@ def mac_address_range_find(context, **filters):
 def mac_address_range_create(context, **range_dict):
     new_range = models.MacAddressRange()
     new_range.update(range_dict)
-    new_range["tenant_id"] = context.tenant_id
     context.session.add(new_range)
     return new_range
 
@@ -467,3 +466,27 @@ def security_group_rule_create(context, **rule_dict):
 
 def security_group_rule_delete(context, rule):
     context.session.delete(rule)
+
+
+def ip_policy_create(context, **ip_policy_dict):
+    new_policy = models.IPPolicy()
+    exclude_set = ip_policy_dict.pop("exclude")
+    for ip_cidr in exclude_set.iter_cidrs():
+        new_policy["exclude"].append(models.IPPolicyRule(
+            address=int(ip_cidr.ip),
+            prefix=ip_cidr.prefixlen))
+
+    new_policy.update(ip_policy_dict)
+    context.session.add(new_policy)
+    return new_policy
+
+
+@scoped
+def ip_policy_find(context, **filters):
+    query = context.session.query(models.IPPolicy)
+    model_filters = _model_query(context, models.IPPolicy, filters)
+    return query.filter(*model_filters)
+
+
+def ip_policy_delete(context, ip_policy):
+    context.session.delete(ip_policy)

--- a/quark/exceptions.py
+++ b/quark/exceptions.py
@@ -55,3 +55,11 @@ class ProvidernetParamError(exceptions.NeutronException):
 
 class BadNVPState(exceptions.NeutronException):
     message = _("No networking information found for network %(net_id)s")
+
+
+class IPPolicyNotFound(exceptions.NeutronException):
+    message = _("IP Policy %(id)s not found.")
+
+
+class IPPolicyAlreadyExists(exceptions.NeutronException):
+    message = _("IP Policy %(id)s already exists for %(n_id)s")

--- a/quark/plugin.py
+++ b/quark/plugin.py
@@ -93,7 +93,7 @@ class Plugin(neutron_plugin_base_v2.NeutronPluginBaseV2,
     supported_extension_aliases = ["mac_address_ranges", "routes",
                                    "ip_addresses", "ports_quark",
                                    "security-group",
-                                   "subnets_quark", "provider"]
+                                   "subnets_quark", "provider", "ip_policies"]
 
     def _initDBMaker(self):
         # This needs to be called after _ENGINE is configured
@@ -1240,3 +1240,57 @@ class Plugin(neutron_plugin_base_v2.NeutronPluginBaseV2,
             group,
             **newgroup)
         return v._make_security_group_dict(dbgroup)
+
+    def create_ip_policy(self, context, ip_policy):
+        LOG.info("create_ip_policy for tenant %s" % context.tenant_id)
+
+        ipp = ip_policy["ip_policy"]
+        network_id = ipp.get("network_id", None)
+        subnet_id = ipp.get("subnet_id", None)
+
+        if not ipp.get("exclude"):
+            raise exceptions.BadRequest(resource="ip_policy",
+                                        msg="Empty ip_policy.exclude regions")
+        ipp["exclude"] = netaddr.IPSet(ipp["exclude"])
+
+        model = None
+        if subnet_id:
+            model = db_api.subnet_find(context, id=subnet_id, scope=db_api.ONE)
+            if not model:
+                raise exceptions.SubnetNotFound(id=subnet_id)
+        elif network_id:
+            model = db_api.network_find(context, id=network_id,
+                                        scope=db_api.ONE)
+            if not model:
+                raise exceptions.NetworkNotFound(id=network_id)
+        else:
+            raise exceptions.BadRequest(
+                resource="ip_policy",
+                msg="network_id or subnet_id unspecified")
+
+        if model["ip_policy"]:
+            raise quark_exceptions.IPPolicyAlreadyExists(
+                id=model["ip_policy"]["id"],
+                n_id=model["id"])
+        model["ip_policy"] = db_api.ip_policy_create(context,
+                                                     **ipp)
+        return v._make_ip_policy_dict(model["ip_policy"])
+
+    def get_ip_policy(self, context, id):
+        LOG.info("get_ip_policy %s for tenant %s" % (id, context.tenant_id))
+        ipp = db_api.ip_policy_find(context, id=id, scope=db_api.ONE)
+        if not ipp:
+            raise quark_exceptions.IPPolicyNotFound(id=id)
+        return v._make_ip_policy_dict(ipp)
+
+    def get_ip_policies(self, context, **filters):
+        LOG.info("get_ip_policies for tenant %s" % (context.tenant_id))
+        ipps = db_api.ip_policy_find(context, scope=db_api.ALL, **filters)
+        return [v._make_ip_policy_dict(ipp) for ipp in ipps]
+
+    def delete_ip_policy(self, context, id):
+        LOG.info("delete_ip_policy %s for tenant %s" % (id, context.tenant_id))
+        ipp = db_api.ip_policy_find(context, id=id, scope=db_api.ONE)
+        if not ipp:
+            raise quark_exceptions.IPPolicyNotFound(id=id)
+        db_api.ip_policy_delete(context, ipp)

--- a/quark/plugin_views.py
+++ b/quark/plugin_views.py
@@ -165,3 +165,12 @@ def _make_ip_dict(address):
             "tenant_id": address["tenant_id"],
             "version": address["version"],
             "shared": len(address["ports"]) > 1}
+
+
+def _make_ip_policy_dict(ipp):
+    excludes = [str(netaddr.IPNetwork((int(ippr["address"]), ippr["prefix"])))
+                for ippr in ipp["exclude"]]
+    return {"id": ipp["id"],
+            "subnet_id": ipp["subnet_id"],
+            "network_id": ipp["network_id"],
+            "exclude": excludes}

--- a/quark/tests/test_quark_plugin.py
+++ b/quark/tests/test_quark_plugin.py
@@ -2058,3 +2058,161 @@ class TestQuarkDeleteSecurityGroupRule(TestQuarkPlugin):
         ) as (db_delete, driver_delete):
             with self.assertRaises(sg_ext.SecurityGroupInUse):
                 self.plugin.delete_security_group_rule(self.context, 1)
+
+
+class TestQuarkGetIpPolicies(TestQuarkPlugin):
+    @contextlib.contextmanager
+    def _stubs(self, ip_policy):
+        db_mod = "quark.db.api"
+        with mock.patch("%s.ip_policy_find" % db_mod) as ip_policy_find:
+            ip_policy_find.return_value = ip_policy
+            yield
+
+    def test_get_ip_policy_not_found(self):
+        with self._stubs(None):
+            with self.assertRaises(quark_exceptions.IPPolicyNotFound):
+                self.plugin.get_ip_policy(self.context, 1)
+
+    def test_get_ip_policy(self):
+        address = int(netaddr.IPAddress("1.1.1.1"))
+        ip_policy = dict(
+            id=1,
+            subnet_id=1,
+            network_id=2,
+            exclude=[dict(address=address, prefix=24)])
+        with self._stubs(ip_policy):
+            resp = self.plugin.get_ip_policy(self.context, 1)
+            self.assertEqual(len(resp.keys()), 4)
+            self.assertEqual(resp["id"], 1)
+            self.assertEqual(resp["subnet_id"], 1)
+            self.assertEqual(resp["network_id"], 2)
+            self.assertEqual(resp["exclude"], ["1.1.1.1/24"])
+
+    def test_get_ip_policies(self):
+        address = int(netaddr.IPAddress("1.1.1.1"))
+        ip_policy = dict(
+            id=1,
+            subnet_id=1,
+            network_id=2,
+            exclude=[dict(address=address, prefix=24)])
+        with self._stubs([ip_policy]):
+            resp = self.plugin.get_ip_policies(self.context)
+            self.assertEqual(len(resp), 1)
+            resp = resp[0]
+            self.assertEqual(len(resp.keys()), 4)
+            self.assertEqual(resp["id"], 1)
+            self.assertEqual(resp["subnet_id"], 1)
+            self.assertEqual(resp["network_id"], 2)
+            self.assertEqual(resp["exclude"], ["1.1.1.1/24"])
+
+
+class TestQuarkCreateIpPolicies(TestQuarkPlugin):
+    @contextlib.contextmanager
+    def _stubs(self, ip_policy, subnet=None, net=None):
+        db_mod = "quark.db.api"
+        with contextlib.nested(
+            mock.patch("%s.subnet_find" % db_mod),
+            mock.patch("%s.network_find" % db_mod),
+            mock.patch("%s.ip_policy_create" % db_mod),
+        ) as (subnet_find, net_find, ip_policy_create):
+            subnet_find.return_value = subnet
+            net_find.return_value = net
+            ip_policy_create.return_value = ip_policy
+            yield ip_policy_create
+
+    def test_create_ip_policy_invalid_body_missing_exclude(self):
+        with self._stubs(None):
+            with self.assertRaises(exceptions.BadRequest):
+                self.plugin.create_ip_policy(self.context, dict(
+                    ip_policy=dict()))
+
+    def test_create_ip_policy_invalid_body_missing_netsubnet(self):
+        with self._stubs(None):
+            with self.assertRaises(exceptions.BadRequest):
+                self.plugin.create_ip_policy(self.context, dict(
+                    ip_policy=dict(exclude=["1.1.1.1/24"])))
+
+    def test_create_ip_policy_invalid_subnet(self):
+        with self._stubs(None):
+            with self.assertRaises(exceptions.SubnetNotFound):
+                self.plugin.create_ip_policy(self.context, dict(
+                    ip_policy=dict(subnet_id=1,
+                                   exclude=["1.1.1.1/24"])))
+
+    def test_create_ip_policy_invalid_network(self):
+        with self._stubs(None):
+            with self.assertRaises(exceptions.NetworkNotFound):
+                self.plugin.create_ip_policy(self.context, dict(
+                    ip_policy=dict(network_id=1,
+                                   exclude=["1.1.1.1/24"])))
+
+    def test_create_ip_policy_network_ip_policy_already_exists(self):
+        with self._stubs(None, net=dict(id=1, ip_policy=dict(id=2))):
+            with self.assertRaises(quark_exceptions.IPPolicyAlreadyExists):
+                self.plugin.create_ip_policy(self.context, dict(
+                    ip_policy=dict(network_id=1,
+                                   exclude=["1.1.1.1/24"])))
+
+    def test_create_ip_policy_subnet_ip_policy_already_exists(self):
+        with self._stubs(None, subnet=dict(id=1, ip_policy=dict(id=2))):
+            with self.assertRaises(quark_exceptions.IPPolicyAlreadyExists):
+                self.plugin.create_ip_policy(self.context, dict(
+                    ip_policy=dict(subnet_id=1,
+                                   exclude=["1.1.1.1/24"])))
+
+    def test_create_ip_policy_network(self):
+        ipp = dict(subnet_id=None, network_id=1,
+                   exclude=[dict(address=int(netaddr.IPAddress("1.1.1.1")),
+                                 prefix=24)])
+        with self._stubs(ipp, net=dict(id=1, ip_policy=dict(id=2))):
+            with self.assertRaises(quark_exceptions.IPPolicyAlreadyExists):
+                resp = self.plugin.create_ip_policy(self.context, dict(
+                    ip_policy=dict(network_id=1,
+                                   exclude=["1.1.1.1/24"])))
+                self.assertEqual(len(resp.keys()), 3)
+                self.assertIsNone(resp["subnet_id"])
+                self.assertEqual(resp["network_id"], 1)
+                self.assertEqual(resp["exclude"], ["1.1.1.1/24"])
+
+    def test_create_ip_policy_subnet(self):
+        ipp = dict(subnet_id=1, network_id=None,
+                   exclude=[dict(address=int(netaddr.IPAddress("1.1.1.1")),
+                                 prefix=24)])
+        with self._stubs(ipp, subnet=dict(id=1, ip_policy=dict(id=2))):
+            with self.assertRaises(quark_exceptions.IPPolicyAlreadyExists):
+                resp = self.plugin.create_ip_policy(self.context, dict(
+                    ip_policy=dict(subnet_id=1,
+                                   exclude=["1.1.1.1/24"])))
+                self.assertEqual(len(resp.keys()), 3)
+                self.assertEqual(resp["subnet_id"], 1)
+                self.assertIsNone(resp["network_id"])
+                self.assertEqual(resp["exclude"], ["1.1.1.1/24"])
+
+
+class TestQuarkDeleteIpPolicies(TestQuarkPlugin):
+    @contextlib.contextmanager
+    def _stubs(self, ip_policy):
+        db_mod = "quark.db.api"
+        with contextlib.nested(
+            mock.patch("%s.ip_policy_find" % db_mod),
+            mock.patch("%s.ip_policy_delete" % db_mod),
+        ) as (ip_policy_find, ip_policy_delete):
+            ip_policy_find.return_value = ip_policy
+            yield ip_policy_find, ip_policy_delete
+
+    def test_delete_ip_policy_not_found(self):
+        with self._stubs(None):
+            with self.assertRaises(quark_exceptions.IPPolicyNotFound):
+                self.plugin.delete_ip_policy(self.context, 1)
+
+    def test_delete_ip_policy(self):
+        address = int(netaddr.IPAddress("1.1.1.1"))
+        ip_policy = dict(
+            id=1,
+            subnet_id=1,
+            network_id=2,
+            exclude=[dict(address=address, prefix=24)])
+        with self._stubs(ip_policy) as (ip_policy_find, ip_policy_delete):
+            self.plugin.delete_ip_policy(self.context, 1)
+            self.assertEqual(ip_policy_find.call_count, 1)
+            self.assertEqual(ip_policy_delete.call_count, 1)


### PR DESCRIPTION
- Implemented CRD ip_policies plugin methods
- Implemented plugin ip_policy unit tests
- Added IP Policy logic to ipam.allocate_ip_address
- Implemented ip_policy ipam unit tests
- Implemented ip_policies extension
- Added ip_policies db models
- Implemented db_api ip_policy methods
- Implemented make_ip_policy_dict view
- Fixed existing tests

An IP Policy is defined on a subnet or network definining what IPs to
exclude from allocation. From a user perspective an IP Policy looks like
the following:

   {
    "subnet_id": <uuid>/None,
    "network_id": <uuid>/None,
    "exclude": list of cidrs (e.g. ["0.0.0.0/31", "0.0.0.255/32"])
   }

One of "subnet_id" or "network_id" is required. "exclude" is always
required. Only create, read, and delete operations are supported.

Only one policy is allowed per network. Thus, if a user would like to
"update" the policy on a network they would have to delete an existing
policy and create a new one.

If a network's IP policy excludes ranges outside of a subnet's cidr, the
IP policy exclusion is only applied as it intersects with the subnet's
cidr.
