### PR TITLE
Unecessary default quota config override.

### DIFF
--- a/quark/plugin.py
+++ b/quark/plugin.py
@@ -66,8 +66,6 @@ quark_opts = [
 
 STRATEGY = network_strategy.STRATEGY
 CONF.register_opts(quark_opts, "QUARK")
-CONF.set_default('quota_security_group', 5, "QUOTAS")
-CONF.set_default('quota_security_group_rule', 20, "QUOTAS")
 
 
 def _pop_param(attrs, param, default=None):


### PR DESCRIPTION
Such an override is the point of the config file and should not be hard-coded.
