### PR TITLE
Quotas API

### DIFF
--- a/quark/exceptions.py
+++ b/quark/exceptions.py
@@ -63,3 +63,7 @@ class IPPolicyNotFound(exceptions.NeutronException):
 
 class IPPolicyAlreadyExists(exceptions.NeutronException):
     message = _("IP Policy %(id)s already exists for %(n_id)s")
+
+
+class DriverLimitReached(exceptions.InvalidInput):
+    message = _("Driver has reached limit on resource '%(limit)s'")

--- a/quark/plugin.py
+++ b/quark/plugin.py
@@ -35,6 +35,7 @@ from neutron.openstack.common.db.sqlalchemy import session as neutron_session
 from neutron.openstack.common import importutils
 from neutron.openstack.common import log as logging
 from neutron.openstack.common import uuidutils
+from neutron import quota
 
 from neutron import neutron_plugin_base_v2
 
@@ -66,8 +67,18 @@ quark_opts = [
                help=_("Path to the config for the net driver"))
 ]
 
+quark_quota_opts = [
+    cfg.IntOpt('quota_ports_per_network',
+               default=64,
+               help=_('Maximum ports per network per tenant')),
+    cfg.IntOpt('quota_security_rules_per_group',
+               default=20,
+               help=_('Maximum security group rules in a group')),
+]
+
 STRATEGY = network_strategy.STRATEGY
 CONF.register_opts(quark_opts, "QUARK")
+CONF.register_opts(quark_quota_opts, "QUOTAS")
 
 
 def _pop_param(attrs, param, default=None):
@@ -93,7 +104,8 @@ class Plugin(neutron_plugin_base_v2.NeutronPluginBaseV2,
     supported_extension_aliases = ["mac_address_ranges", "routes",
                                    "ip_addresses", "ports_quark",
                                    "security-group",
-                                   "subnets_quark", "provider", "ip_policies"]
+                                   "subnets_quark", "provider",
+                                   "ip_policies", "quotas"]
 
     def _initDBMaker(self):
         # This needs to be called after _ENGINE is configured
@@ -124,6 +136,14 @@ class Plugin(neutron_plugin_base_v2.NeutronPluginBaseV2,
         self.ipam_driver = (importutils.import_class(CONF.QUARK.ipam_driver))()
         self.ipam_reuse_after = CONF.QUARK.ipam_reuse_after
         neutron_db_api.register_models(base=models.BASEV2)
+
+        quark_resources = [
+            quota.BaseResource('ports_per_network',
+                               'quota_ports_per_network'),
+            quota.BaseResource('security_rules_per_group',
+                               'quota_security_rules_per_group'),
+        ]
+        quota.QUOTAS.register_resources(quark_resources)
 
     def _make_security_group_list(self, context, group_ids):
         if not group_ids or group_ids is attributes.ATTR_NOT_SPECIFIED:
@@ -589,6 +609,10 @@ class Plugin(neutron_plugin_base_v2.NeutronPluginBaseV2,
             net = db_api.network_find(context, id=net_id, scope=db_api.ONE)
             if not net:
                 raise exceptions.NetworkNotFound(net_id=net_id)
+
+        quota.QUOTAS.limit_check(
+            context, context.tenant_id,
+            ports_per_network=len(net.get('ports', []))+1)
 
         if fixed_ips:
             for fixed_ip in fixed_ips:
@@ -1080,9 +1104,6 @@ class Plugin(neutron_plugin_base_v2.NeutronPluginBaseV2,
     def create_security_group(self, context, security_group):
         LOG.info("create_security_group for tenant %s" %
                 (context.tenant_id))
-        if (db_api.security_group_find(context).count() >=
-                CONF.QUOTAS.quota_security_group):
-            raise exceptions.OverQuota(overs="security groups")
         group = security_group["security_group"]
         group_name = group.get('name', '')
         if group_name == "default":
@@ -1107,14 +1128,13 @@ class Plugin(neutron_plugin_base_v2.NeutronPluginBaseV2,
             'group_id': '00000000-0000-0000-0000-000000000000',
             'port_egress_rules': [],
             'port_ingress_rules': [
-                {'ethertype': 'IPv4', 'protocol': 6,
-                    'port_range_min': 0, 'port_range_max': 65535},
-                {'ethertype': 'IPv4', 'protocol': 17,
-                    'port_range_min': 0, 'port_range_max': 65535},
-                {'ethertype': 'IPv6', 'protocol': 6,
-                    'port_range_min': 0, 'port_range_max': 65535},
-                {'ethertype': 'IPv6', 'protocol': 17,
-                    'port_range_min': 0, 'port_range_max': 65535}]}
+                {'ethertype': 'IPv4', 'protocol': 1},
+                {'ethertype': 'IPv4', 'protocol': 6},
+                {'ethertype': 'IPv4', 'protocol': 17},
+                {'ethertype': 'IPv6', 'protocol': 1},
+                {'ethertype': 'IPv6', 'protocol': 6},
+                {'ethertype': 'IPv6', 'protocol': 17},
+            ]}
 
         self.net_driver.create_security_group(
             context,
@@ -1134,9 +1154,6 @@ class Plugin(neutron_plugin_base_v2.NeutronPluginBaseV2,
     def create_security_group_rule(self, context, security_group_rule):
         LOG.info("create_security_group for tenant %s" %
                 (context.tenant_id))
-        if (db_api.security_group_rule_find(context).count() >=
-                CONF.QUOTAS.quota_security_group_rule):
-            raise exceptions.OverQuota(overs="security group rules")
         rule = self._validate_security_group_rule(
             context, security_group_rule["security_group_rule"])
         rule['id'] = uuidutils.generate_uuid()
@@ -1146,6 +1163,10 @@ class Plugin(neutron_plugin_base_v2.NeutronPluginBaseV2,
                                            scope=db_api.ONE)
         if not group:
             raise sg_ext.SecurityGroupNotFound(group_id=group_id)
+
+        quota.QUOTAS.limit_check(
+            context, context.tenant_id,
+            security_rules_per_group=len(group.get('rules', []))+1)
 
         self.net_driver.create_security_group_rule(
             context,

--- a/quark/plugin.py
+++ b/quark/plugin.py
@@ -1146,8 +1146,6 @@ class Plugin(neutron_plugin_base_v2.NeutronPluginBaseV2,
                                            scope=db_api.ONE)
         if not group:
             raise sg_ext.SecurityGroupNotFound(group_id=group_id)
-        if group.ports:
-            raise sg_ext.SecurityGroupInUse(id=group_id)
 
         self.net_driver.create_security_group_rule(
             context,
@@ -1183,8 +1181,6 @@ class Plugin(neutron_plugin_base_v2.NeutronPluginBaseV2,
                                            scope=db_api.ONE)
         if not group:
             raise sg_ext.SecurityGroupNotFound(id=id)
-        if group.ports:
-            raise sg_ext.SecurityGroupInUse(id=id)
 
         self.net_driver.delete_security_group_rule(
             context,

--- a/quark/quota_driver.py
+++ b/quark/quota_driver.py
@@ -1,0 +1,49 @@
+# vim: tabstop=4 shiftwidth=4 softtabstop=4
+
+# Copyright 2011 OpenStack Foundation.
+# All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+from neutron.db import quota_db
+
+
+class QuarkQuotaDriver(quota_db.DbQuotaDriver):
+    """Driver to perform necessary checks to enforce quotas and obtain quota
+    information.
+
+    The default driver utilizes the local database.
+    """
+
+    @staticmethod
+    def delete_tenant_quota(context, tenant_id):
+        """Delete the quota entries for a given tenant_id.
+
+        Atfer deletion, this tenant will use default quota values in conf.
+        """
+        tenant_quotas = context.session.query(quota_db.Quota)
+        tenant_quotas = tenant_quotas.filter_by(tenant_id=tenant_id)
+        tenant_quotas.delete()
+
+    @staticmethod
+    def update_quota_limit(context, tenant_id, resource, limit):
+        tenant_quota = context.session.query(quota_db.Quota).filter_by(
+            tenant_id=tenant_id, resource=resource).first()
+
+        if tenant_quota:
+            tenant_quota.update({'limit': limit})
+        else:
+            tenant_quota = quota_db.Quota(tenant_id=tenant_id,
+                                          resource=resource,
+                                          limit=limit)
+            context.session.add(tenant_quota)

--- a/quark/tests/test_optimized_nvp_driver.py
+++ b/quark/tests/test_optimized_nvp_driver.py
@@ -161,7 +161,7 @@ class TestOptimizedNVPDriverCreatePort(TestOptimizedNVPDriver):
         '''Testing to ensure a switch is made when maxed.'''
         with self._stubs(maxed_ports=True) as (
                 connection, create_opt):
-            self.driver.max_ports_per_switch = self.max_spanning
+            self.driver.limits['max_ports_per_switch'] = self.max_spanning
             port = self.driver.create_port(self.context, self.net_id,
                                            self.port_id)
             self.assertTrue("uuid" in port)

--- a/quark/tests/test_quark_plugin.py
+++ b/quark/tests/test_quark_plugin.py
@@ -1836,15 +1836,6 @@ class TestQuarkCreateSecurityGroup(TestQuarkPlugin):
                     self.context, {'security_group': group})
                 self.assertTrue(group_create.called)
 
-    def test_create_security_group_over_quota(self):
-        group = {'name': 'foo', 'description': 'bar',
-                 'tenant_id': self.context.tenant_id}
-        with self._stubs(group, other=1) as group_create:
-            with self.assertRaises(exceptions.OverQuota):
-                self.plugin.create_security_group(
-                    self.context, {'security_group': group})
-                self.assertTrue(group_create.called)
-
 
 class TestQuarkDeleteSecurityGroup(TestQuarkPlugin):
     @contextlib.contextmanager
@@ -1982,22 +1973,6 @@ class TestQuarkCreateSecurityGroupRule(TestQuarkPlugin):
         with self.assertRaises(sg_ext.SecurityGroupNotFound):
             self._test_create_security_rule(group=None)
 
-    def test_create_security_rule_over_quota(self):
-        rule = self.rule
-        rule.pop('group')
-        with self._stubs(
-                rule,
-                {'id': 1, 'port_rules': 1}
-        ) as rule_create:
-            with self.assertRaises(exceptions.OverQuota):
-                self.plugin.create_security_group_rule(
-                    self.context, {'security_group_rule': self.rule})
-                self.assertTrue(rule_create.called)
-
-    def test_create_security_rule_group_in_use(self):
-        with self.assertRaises(sg_ext.SecurityGroupInUse):
-            self._test_create_security_rule(group={'ports': [models.Port()]})
-
 
 class TestQuarkDeleteSecurityGroupRule(TestQuarkPlugin):
     @contextlib.contextmanager
@@ -2049,14 +2024,6 @@ class TestQuarkDeleteSecurityGroupRule(TestQuarkPlugin):
         with self._stubs(dict(rule, group_id=1),
                          None) as (db_delete, driver_delete):
             with self.assertRaises(sg_ext.SecurityGroupNotFound):
-                self.plugin.delete_security_group_rule(self.context, 1)
-
-    def test_delete_security_group_rule_group_in_use(self):
-        with self._stubs(
-                rule={'id': 1, 'security_group_id': 1},
-                group={'id': 1, 'ports': [models.Port()]}
-        ) as (db_delete, driver_delete):
-            with self.assertRaises(sg_ext.SecurityGroupInUse):
                 self.plugin.delete_security_group_rule(self.context, 1)
 
 


### PR DESCRIPTION
Sits atop quantum.quota.QuotaEngine and quantum.extensions.quotasv2. Extends and replaces quantum.db.quota_db.DbQuotaDriver with QuarkQuotaDriver which is repoze transaction aware (not that DbQuotaDriver wasn't...).
For hierarchal quota checks (ie, rules per group) the plugin must call the QuotaEngine independently of quantum. Implemented in config file in QUOTAS group as quota_X_per_Y.

Requires the config flag:

[QUOTAS]
...
quota_driver = quark.quota_driver.QuarkQuotaDriver
...
