### PR TITLE
Quotas API and driver limits implemented

### DIFF
--- a/quark/drivers/base.py
+++ b/quark/drivers/base.py
@@ -13,6 +13,7 @@
 #    License for the specific language governing permissions and limitations
 #
 
+import contextlib
 from quantum.openstack.common import log as logging
 
 LOG = logging.getLogger("quantum.quark.base")
@@ -28,6 +29,15 @@ class BaseDriver(object):
 
     def get_connection(self):
         LOG.info("get_connection")
+
+    @contextlib.contextmanager
+    def limits_checked(self, limits):
+        LOG.debug("plugin is checking %s" % limits)
+        yield
+
+    def get_driver_limits(self, limits):
+        LOG.info("get_driver_limits")
+        return dict((limit, None) for limit in limits.keys())
 
     def create_network(self, tenant_id, network_name, tags=None,
                        network_id=None, **kwargs):

--- a/quark/drivers/optimized_nvp_driver.py
+++ b/quark/drivers/optimized_nvp_driver.py
@@ -96,7 +96,6 @@ class OptimizedNVPDriver(NVPDriver):
             first()
         return port
 
-        #self.net_driver.get_driver_limits({'max_rules_per_group', True})
     def _lswitch_delete(self, context, lswitch_uuid):
         switch = self._lswitch_select_by_nvp_id(context, lswitch_uuid)
         super(OptimizedNVPDriver, self).\

--- a/quark/drivers/optimized_nvp_driver.py
+++ b/quark/drivers/optimized_nvp_driver.py
@@ -96,6 +96,7 @@ class OptimizedNVPDriver(NVPDriver):
             first()
         return port
 
+        #self.net_driver.get_driver_limits({'max_rules_per_group', True})
     def _lswitch_delete(self, context, lswitch_uuid):
         switch = self._lswitch_select_by_nvp_id(context, lswitch_uuid)
         super(OptimizedNVPDriver, self).\
@@ -115,7 +116,8 @@ class OptimizedNVPDriver(NVPDriver):
 
     def _lswitch_select_free(self, context, network_id):
         query = context.session.query(LSwitch)
-        query = query.filter(LSwitch.port_count < self.max_ports_per_switch)
+        query = query.filter(LSwitch.port_count <
+                             self.limits['max_ports_per_switch'])
         query = query.filter(LSwitch.network_id == network_id)
         switch = query.order_by(LSwitch.port_count).first()
         return switch
@@ -129,7 +131,7 @@ class OptimizedNVPDriver(NVPDriver):
         pass
 
     def _lswitch_select_open(self, context, network_id=None, **kwargs):
-        if self.max_ports_per_switch == 0:
+        if self.limits['max_ports_per_switch'] == 0:
             switch = self._lswitch_select_first(context, network_id)
         else:
             switch = self._lswitch_select_free(context, network_id)
@@ -203,6 +205,15 @@ class OptimizedNVPDriver(NVPDriver):
         return {'uuid': self._get_security_group_id(context, group_id),
                 'logical_port_ingress_rules': rulelist['ingress'],
                 'logical_port_egress_rules': rulelist['egress']}
+
+    def _check_rule_count_per_port(self, context, group_id):
+        ports = context.session.query(models.SecurityGroup).filter(
+            models.SecurityGroup.id == group_id).first().get('ports', [])
+        groups = set(group.id for port in ports for group in
+                     port.get('security_groups', []))
+        return self._check_rule_count_for_groups(
+            context,
+            (self._get_security_group(context, id) for id in groups))
 
 
 class LSwitchPort(models.BASEV2, models.HasId):

--- a/quark/exceptions.py
+++ b/quark/exceptions.py
@@ -55,3 +55,7 @@ class ProvidernetParamError(exceptions.QuantumException):
 
 class BadNVPState(exceptions.QuantumException):
     message = _("No networking information found for network %(net_id)s")
+
+
+class DriverLimitReached(exceptions.InvalidInput):
+    message = _("Driver has reached limit on resource '%(limit)s'")

--- a/quark/plugin.py
+++ b/quark/plugin.py
@@ -1146,8 +1146,6 @@ class Plugin(quantum_plugin_base_v2.QuantumPluginBaseV2,
                                            scope=db_api.ONE)
         if not group:
             raise sg_ext.SecurityGroupNotFound(group_id=group_id)
-        if group.ports:
-            raise sg_ext.SecurityGroupInUse(id=group_id)
 
         self.net_driver.create_security_group_rule(
             context,
@@ -1183,8 +1181,6 @@ class Plugin(quantum_plugin_base_v2.QuantumPluginBaseV2,
                                            scope=db_api.ONE)
         if not group:
             raise sg_ext.SecurityGroupNotFound(id=id)
-        if group.ports:
-            raise sg_ext.SecurityGroupInUse(id=id)
 
         self.net_driver.delete_security_group_rule(
             context,

--- a/quark/quota_driver.py
+++ b/quark/quota_driver.py
@@ -1,0 +1,49 @@
+# vim: tabstop=4 shiftwidth=4 softtabstop=4
+
+# Copyright 2011 OpenStack Foundation.
+# All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+from quantum.db import quota_db
+
+
+class QuarkQuotaDriver(quota_db.DbQuotaDriver):
+    """Driver to perform necessary checks to enforce quotas and obtain quota
+    information.
+
+    The default driver utilizes the local database.
+    """
+
+    @staticmethod
+    def delete_tenant_quota(context, tenant_id):
+        """Delete the quota entries for a given tenant_id.
+
+        Atfer deletion, this tenant will use default quota values in conf.
+        """
+        tenant_quotas = context.session.query(quota_db.Quota)
+        tenant_quotas = tenant_quotas.filter_by(tenant_id=tenant_id)
+        tenant_quotas.delete()
+
+    @staticmethod
+    def update_quota_limit(context, tenant_id, resource, limit):
+        tenant_quota = context.session.query(quota_db.Quota).filter_by(
+            tenant_id=tenant_id, resource=resource).first()
+
+        if tenant_quota:
+            tenant_quota.update({'limit': limit})
+        else:
+            tenant_quota = quota_db.Quota(tenant_id=tenant_id,
+                                          resource=resource,
+                                          limit=limit)
+            context.session.add(tenant_quota)

--- a/quark/tests/test_optimized_nvp_driver.py
+++ b/quark/tests/test_optimized_nvp_driver.py
@@ -161,7 +161,7 @@ class TestOptimizedNVPDriverCreatePort(TestOptimizedNVPDriver):
         '''Testing to ensure a switch is made when maxed.'''
         with self._stubs(maxed_ports=True) as (
                 connection, create_opt):
-            self.driver.max_ports_per_switch = self.max_spanning
+            self.driver.limits['max_ports_per_switch'] = self.max_spanning
             port = self.driver.create_port(self.context, self.net_id,
                                            self.port_id)
             self.assertTrue("uuid" in port)

--- a/quark/tests/test_quark_plugin.py
+++ b/quark/tests/test_quark_plugin.py
@@ -37,6 +37,7 @@ class TestQuarkPlugin(test_base.TestBase):
     def setUp(self):
         super(TestQuarkPlugin, self).setUp()
 
+        cfg.CONF.set_override('quota_ports_per_network', 1, 'QUOTAS')
         cfg.CONF.set_override('connection', 'sqlite://', 'database')
         db_api.configure_db()
         self.plugin = quark.plugin.Plugin()
@@ -1219,6 +1220,18 @@ class TestQuarkCreatePort(TestQuarkPlugin):
             with self.assertRaises(exceptions.NetworkNotFound):
                 self.plugin.create_port(self.context, port)
 
+    def test_create_port_net_at_max(self):
+        network = dict(id=1, ports=[models.Port()])
+        mac = dict(address="aa:bb:cc:dd:ee:ff")
+        port_name = "foobar"
+        ip = dict()
+        port = dict(port=dict(mac_address=mac["address"], network_id=1,
+                              tenant_id=self.context.tenant_id, device_id=2,
+                              name=port_name))
+        with self._stubs(port=port["port"], network=network, addr=ip, mac=mac):
+            with self.assertRaises(exceptions.OverQuota):
+                self.plugin.create_port(self.context, port)
+
     def test_create_port_security_groups(self, groups=[1]):
         network = dict(id=1)
         mac = dict(address="aa:bb:cc:dd:ee:ff")
@@ -1888,6 +1901,7 @@ class TestQuarkCreateSecurityGroupRule(TestQuarkPlugin):
     def setUp(self, *args, **kwargs):
         super(TestQuarkCreateSecurityGroupRule, self).setUp(*args, **kwargs)
         cfg.CONF.set_override('quota_security_group_rule', 1, 'QUOTAS')
+        cfg.CONF.set_override('quota_security_rules_per_group', 1, 'QUOTAS')
         self.rule = {'id': 1, 'ethertype': 'IPv4',
                      'security_group_id': 1, 'group': {'id': 1}}
         self.expected = {
@@ -1909,6 +1923,7 @@ class TestQuarkCreateSecurityGroupRule(TestQuarkPlugin):
         dbrule.group_id = rule['security_group_id']
         dbgroup = None
         if group:
+            print group
             dbgroup = models.SecurityGroup()
             dbgroup.update(group)
 
@@ -1928,6 +1943,7 @@ class TestQuarkCreateSecurityGroupRule(TestQuarkPlugin):
         rule = dict(self.rule, **ruleset)
         group = rule.pop('group')
         expected = dict(self.expected, **ruleset)
+        expected.pop('group', None)
         with self._stubs(rule, group) as rule_create:
             result = self.plugin.create_security_group_rule(
                 self.context, {'security_group_rule': rule})
@@ -1972,6 +1988,11 @@ class TestQuarkCreateSecurityGroupRule(TestQuarkPlugin):
     def test_create_security_rule_no_group(self):
         with self.assertRaises(sg_ext.SecurityGroupNotFound):
             self._test_create_security_rule(group=None)
+
+    def test_create_security_rule_group_at_max(self):
+        with self.assertRaises(exceptions.OverQuota):
+            self._test_create_security_rule(
+                group={'id': 1, 'rules': [models.SecurityGroupRule()]})
 
 
 class TestQuarkDeleteSecurityGroupRule(TestQuarkPlugin):

--- a/quark/tests/test_quark_plugin.py
+++ b/quark/tests/test_quark_plugin.py
@@ -1836,15 +1836,6 @@ class TestQuarkCreateSecurityGroup(TestQuarkPlugin):
                     self.context, {'security_group': group})
                 self.assertTrue(group_create.called)
 
-    def test_create_security_group_over_quota(self):
-        group = {'name': 'foo', 'description': 'bar',
-                 'tenant_id': self.context.tenant_id}
-        with self._stubs(group, other=1) as group_create:
-            with self.assertRaises(exceptions.OverQuota):
-                self.plugin.create_security_group(
-                    self.context, {'security_group': group})
-                self.assertTrue(group_create.called)
-
 
 class TestQuarkDeleteSecurityGroup(TestQuarkPlugin):
     @contextlib.contextmanager
@@ -1982,22 +1973,6 @@ class TestQuarkCreateSecurityGroupRule(TestQuarkPlugin):
         with self.assertRaises(sg_ext.SecurityGroupNotFound):
             self._test_create_security_rule(group=None)
 
-    def test_create_security_rule_over_quota(self):
-        rule = self.rule
-        rule.pop('group')
-        with self._stubs(
-                rule,
-                {'id': 1, 'port_rules': 1}
-        ) as rule_create:
-            with self.assertRaises(exceptions.OverQuota):
-                self.plugin.create_security_group_rule(
-                    self.context, {'security_group_rule': self.rule})
-                self.assertTrue(rule_create.called)
-
-    def test_create_security_rule_group_in_use(self):
-        with self.assertRaises(sg_ext.SecurityGroupInUse):
-            self._test_create_security_rule(group={'ports': [models.Port()]})
-
 
 class TestQuarkDeleteSecurityGroupRule(TestQuarkPlugin):
     @contextlib.contextmanager
@@ -2049,12 +2024,4 @@ class TestQuarkDeleteSecurityGroupRule(TestQuarkPlugin):
         with self._stubs(dict(rule, group_id=1),
                          None) as (db_delete, driver_delete):
             with self.assertRaises(sg_ext.SecurityGroupNotFound):
-                self.plugin.delete_security_group_rule(self.context, 1)
-
-    def test_delete_security_group_rule_group_in_use(self):
-        with self._stubs(
-                rule={'id': 1, 'security_group_id': 1},
-                group={'id': 1, 'ports': [models.Port()]}
-        ) as (db_delete, driver_delete):
-            with self.assertRaises(sg_ext.SecurityGroupInUse):
                 self.plugin.delete_security_group_rule(self.context, 1)

--- a/quark/tests/test_quark_plugin.py
+++ b/quark/tests/test_quark_plugin.py
@@ -1923,7 +1923,6 @@ class TestQuarkCreateSecurityGroupRule(TestQuarkPlugin):
         dbrule.group_id = rule['security_group_id']
         dbgroup = None
         if group:
-            print group
             dbgroup = models.SecurityGroup()
             dbgroup.update(group)
 


### PR DESCRIPTION
Combination of #120 and #122.

Quotas API:
Sits atop quantum.quota.QuotaEngine and quantum.extensions.quotasv2. Extends and replaces quantum.db.quota_db.DbQuotaDriver with QuarkQuotaDriver.
For hierarchal quota checks (ie, rules per group) the plugin must call the QuotaEngine independently of quantum. Implemented in config file in QUOTAS group as quota_X_per_Y.

Requires the config flag:
[QUOTAS]
quota_driver = quark.quota_driver.QuarkQuotaDriver

Driver limits:
Separates the business logic of quotas from the limits in the specific driver implementation. Also allows the plugin to check limits in the case that it is more efficient than doing it in the driver.
