### PR TITLE
Fakes out net and port status fixes quoting

### DIFF
--- a/quark/plugin_views.py
+++ b/quark/plugin_views.py
@@ -31,16 +31,16 @@ STRATEGY = network_strategy.STRATEGY
 
 def _make_network_dict(network, fields=None):
     shared_net = STRATEGY.is_parent_network(network["id"])
-    res = {'id': network["id"],
-           'name': network.get('name'),
-           'tenant_id': network.get('tenant_id'),
-           'admin_state_up': None,
-           'status': network.get('status'),
-           'shared': shared_net,
+    res = {"id": network["id"],
+           "name": network.get("name"),
+           "tenant_id": network.get("tenant_id"),
+           "admin_state_up": None,
+           "status": "ACTIVE",
+           "shared": shared_net,
            #TODO(mdietz): this is the expected return. Then the client
            #              foolishly turns around and asks for the entire
            #              subnet list anyway! Plz2fix
-           'subnets': [s["id"] for s in network.get("subnets", [])]}
+           "subnets": [s["id"] for s in network.get("subnets", [])]}
     return res
 
 
@@ -74,14 +74,14 @@ def _make_subnet_dict(subnet, default_route=None, fields=None):
         pools.append(dict(start=str(pool_start), end=str(prev_cidr_end)))
         return pools
 
-    res = {"id": subnet.get('id'),
-           "name": subnet.get('name'),
-           "tenant_id": subnet.get('tenant_id'),
+    res = {"id": subnet.get("id"),
+           "name": subnet.get("name"),
+           "tenant_id": subnet.get("tenant_id"),
            "network_id": net_id,
-           "ip_version": subnet.get('ip_version'),
+           "ip_version": subnet.get("ip_version"),
            "allocation_pools": _allocation_pools(subnet),
            "dns_nameservers": dns_nameservers or [],
-           "cidr": subnet.get('cidr'),
+           "cidr": subnet.get("cidr"),
            "enable_dhcp": None}
 
     def _host_route(route):
@@ -106,7 +106,7 @@ def _make_security_group_dict(security_group, fields=None):
            "name": security_group.get("name"),
            "tenant_id": security_group.get("tenant_id")}
     res["security_group_rules"] = [
-        r.id for r in security_group['rules']]
+        r.id for r in security_group["rules"]]
     return res
 
 
@@ -131,8 +131,8 @@ def _port_dict(port, fields=None):
            "tenant_id": port.get("tenant_id"),
            "mac_address": port.get("mac_address"),
            "admin_state_up": port.get("admin_state_up"),
-           "status": port.get("status"),
-           "security_groups": [group.get('id', None) for group in
+           "status": "ACTIVE",
+           "security_groups": [group.get("id", None) for group in
                                port.get("security_groups", None)],
            "device_id": port.get("device_id"),
            "device_owner": port.get("device_owner")}
@@ -143,8 +143,8 @@ def _port_dict(port, fields=None):
 
 
 def _make_port_address_dict(ip):
-    return {'subnet_id': ip.get("subnet_id"),
-            'ip_address': ip.formatted()}
+    return {"subnet_id": ip.get("subnet_id"),
+            "ip_address": ip.formatted()}
 
 
 def _make_port_dict(port, fields=None):

--- a/quark/tests/plugin_modules/test_networks.py
+++ b/quark/tests/plugin_modules/test_networks.py
@@ -54,7 +54,7 @@ class TestQuarkGetNetworks(test_quark_plugin.TestQuarkPlugin):
     def test_get_networks(self):
         subnet = dict(id=1)
         net = dict(id=1, tenant_id=self.context.tenant_id, name="public",
-                   status="active")
+                   status="ACTIVE")
         with self._stubs(nets=[net], subnets=[subnet]):
             nets = self.plugin.get_networks(self.context, {})
             for key in net.keys():
@@ -64,11 +64,11 @@ class TestQuarkGetNetworks(test_quark_plugin.TestQuarkPlugin):
     def test_get_network(self):
         subnet = dict(id=1)
         net = dict(id=1, tenant_id=self.context.tenant_id, name="public",
-                   status="active")
+                   status="ACTIVE")
         expected = net.copy()
         expected["admin_state_up"] = None
         expected["shared"] = False
-        expected["status"] = "active"
+        expected["status"] = "ACTIVE"
         with self._stubs(nets=net, subnets=[subnet]):
             res = self.plugin.get_network(self.context, 1)
             for key in expected.keys():
@@ -209,7 +209,7 @@ class TestQuarkCreateNetwork(test_quark_plugin.TestQuarkPlugin):
             self.assertIsNotNone(net["id"])
             self.assertEqual(net["name"], "public")
             self.assertIsNone(net["admin_state_up"])
-            self.assertIsNone(net["status"])
+            self.assertEqual(net["status"], "ACTIVE")
             self.assertEqual(net["subnets"], [])
             self.assertEqual(net["shared"], False)
             self.assertEqual(net["tenant_id"], 0)

--- a/quark/tests/plugin_modules/test_ports.py
+++ b/quark/tests/plugin_modules/test_ports.py
@@ -71,7 +71,7 @@ class TestQuarkGetPorts(test_quark_plugin.TestQuarkPlugin):
                   subnet_id=1, network_id=2, version=4)
         port = dict(mac_address="aa:bb:cc:dd:ee:ff", network_id=1,
                     tenant_id=self.context.tenant_id, device_id=2)
-        expected = {'status': None,
+        expected = {'status': "ACTIVE",
                     'device_owner': None,
                     'mac_address': 'aa:bb:cc:dd:ee:ff',
                     'network_id': 1,
@@ -94,7 +94,7 @@ class TestQuarkGetPorts(test_quark_plugin.TestQuarkPlugin):
                   subnet_id=1, network_id=2, version=4)
         port = dict(mac_address="AA:BB:CC:DD:EE:FF", network_id=1,
                     tenant_id=self.context.tenant_id, device_id=2)
-        expected = {'status': None,
+        expected = {'status': "ACTIVE",
                     'device_owner': None,
                     'mac_address': 'AA:BB:CC:DD:EE:FF',
                     'network_id': 1,
@@ -113,7 +113,7 @@ class TestQuarkGetPorts(test_quark_plugin.TestQuarkPlugin):
     def test_port_show_with_int_mac(self):
         port = dict(mac_address=187723572702975L, network_id=1,
                     tenant_id=self.context.tenant_id, device_id=2)
-        expected = {'status': None,
+        expected = {'status': "ACTIVE",
                     'device_owner': None,
                     'mac_address': 'aa:bb:cc:dd:ee:ff',
                     'network_id': 1,
@@ -161,7 +161,7 @@ class TestQuarkCreatePort(test_quark_plugin.TestQuarkPlugin):
         port = dict(port=dict(mac_address=mac["address"], network_id=1,
                               tenant_id=self.context.tenant_id, device_id=2,
                               name=port_name))
-        expected = {'status': None,
+        expected = {'status': "ACTIVE",
                     'name': port_name,
                     'device_owner': None,
                     'mac_address': mac["address"],
@@ -183,7 +183,7 @@ class TestQuarkCreatePort(test_quark_plugin.TestQuarkPlugin):
         ip = dict()
         port = dict(port=dict(mac_address=mac["address"], network_id=1,
                               tenant_id=self.context.tenant_id, device_id=2))
-        expected = {'status': None,
+        expected = {'status': "ACTIVE",
                     'device_owner': None,
                     'mac_address': mac["address"],
                     'network_id': network["id"],
@@ -209,7 +209,7 @@ class TestQuarkCreatePort(test_quark_plugin.TestQuarkPlugin):
         port = dict(port=dict(mac_address=mac["address"], network_id=1,
                               tenant_id=self.context.tenant_id, device_id=2,
                               fixed_ips=fixed_ips, ip_addresses=[ip]))
-        expected = {'status': None,
+        expected = {'status': "ACTIVE",
                     'device_owner': None,
                     'mac_address': mac["address"],
                     'network_id': network["id"],
@@ -269,7 +269,7 @@ class TestQuarkCreatePort(test_quark_plugin.TestQuarkPlugin):
         port = dict(port=dict(mac_address=mac["address"], network_id=1,
                               tenant_id=self.context.tenant_id, device_id=2,
                               name=port_name, security_groups=[group]))
-        expected = {'status': None,
+        expected = {'status': "ACTIVE",
                     'name': port_name,
                     'device_owner': None,
                     'mac_address': mac["address"],


### PR DESCRIPTION
Since we don't intend to actually hit the backend for status, there's no sense in modeling it, and therefore no reason to not just return "ACTIVE" all the time.

Also cleans up a bunch of single quote singles out of extreme pedantry.
