### PR TITLE
Adds coverage over drivers and db custom types

### DIFF
--- a/quark/__init__.py
+++ b/quark/__init__.py
@@ -30,9 +30,7 @@ quark_opts = [
                        "after deallocation.")),
     cfg.StrOpt("strategy_driver",
                default='quark.network_strategy.JSONStrategy',
-               help=_("Tree of network assignment strategy")),
-    cfg.StrOpt('net_driver_cfg', default='/etc/neutron/quark.ini',
-               help=_("Path to the config for the net driver"))
+               help=_("Tree of network assignment strategy"))
 ]
 
 

--- a/quark/drivers/base.py
+++ b/quark/drivers/base.py
@@ -23,15 +23,15 @@ class BaseDriver(object):
 
     Usable as a replacement for the sample plugin.
     """
-    def load_config(self, path):
-        LOG.info("load_config %s" % path)
+    def load_config(self):
+        LOG.info("load_config")
 
     def get_connection(self):
         LOG.info("get_connection")
 
-    def create_network(self, tenant_id, network_name, tags=None,
+    def create_network(self, context, network_name, tags=None,
                        network_id=None, **kwargs):
-        LOG.info("create_network %s %s %s" % (tenant_id, network_name,
+        LOG.info("create_network %s %s %s" % (context, network_name,
                                               tags))
 
     def delete_network(self, context, network_id):

--- a/quark/drivers/nvp_driver.py
+++ b/quark/drivers/nvp_driver.py
@@ -68,7 +68,7 @@ class NVPDriver(base.BaseDriver):
                        'max_rules_per_group': 0,
                        'max_rules_per_port': 0}
 
-    def load_config(self, path):
+    def load_config(self):
         #NOTE(mdietz): What does default_tz actually mean?
         #              We don't have one default.
         default_tz = CONF.NVP.default_tz

--- a/quark/plugin_modules/networks.py
+++ b/quark/plugin_modules/networks.py
@@ -36,7 +36,7 @@ STRATEGY = network_strategy.STRATEGY
 
 ipam_driver = (importutils.import_class(CONF.QUARK.ipam_driver))()
 net_driver = (importutils.import_class(CONF.QUARK.net_driver))()
-net_driver.load_config(CONF.QUARK.net_driver_cfg)
+net_driver.load_config()
 
 
 def _adapt_provider_nets(context, network):

--- a/quark/plugin_modules/ports.py
+++ b/quark/plugin_modules/ports.py
@@ -31,7 +31,7 @@ LOG = logging.getLogger("neutron.quark")
 
 ipam_driver = (importutils.import_class(CONF.QUARK.ipam_driver))()
 net_driver = (importutils.import_class(CONF.QUARK.net_driver))()
-net_driver.load_config(CONF.QUARK.net_driver_cfg)
+net_driver.load_config()
 
 
 def create_port(context, port):

--- a/quark/plugin_modules/security_groups.py
+++ b/quark/plugin_modules/security_groups.py
@@ -31,7 +31,7 @@ DEFAULT_SG_UUID = "00000000-0000-0000-0000-000000000000"
 
 
 net_driver = (importutils.import_class(CONF.QUARK.net_driver))()
-net_driver.load_config(CONF.QUARK.net_driver_cfg)
+net_driver.load_config()
 
 
 def _validate_security_group_rule(context, rule):

--- a/quark/tests/test_base_driver.py
+++ b/quark/tests/test_base_driver.py
@@ -1,0 +1,68 @@
+# Copyright (c) 2013 OpenStack Foundation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from quark.drivers import base
+from quark.tests import test_base
+
+
+class TestBaseDriver(test_base.TestBase):
+    def setUp(self):
+        super(TestBaseDriver, self).setUp()
+        self.driver = base.BaseDriver()
+
+    def test_load_config(self):
+        self.driver.load_config()
+
+    def test_get_connection(self):
+        self.driver.get_connection()
+
+    def test_create_network(self):
+        self.driver.create_network(context=self.context, network_name="public")
+
+    def test_delete_network(self):
+        self.driver.delete_network(context=self.context, network_id=1)
+
+    def test_create_port(self):
+        self.driver.create_port(context=self.context, network_id=1, port_id=2)
+
+    def test_update_port(self):
+        self.driver.update_port(context=self.context, network_id=1, port_id=2)
+
+    def test_delete_port(self):
+        self.driver.delete_port(context=self.context, port_id=2)
+
+    def test_create_security_group(self):
+        self.driver.create_security_group(context=self.context,
+                                          group_name="mygroup")
+
+    def test_delete_security_group(self):
+        self.driver.delete_security_group(context=self.context,
+                                          group_id=3)
+
+    def test_update_security_group(self):
+        self.driver.update_security_group(context=self.context,
+                                          group_id=3)
+
+    def test_create_security_group_rule(self):
+        rule = {'ethertype': 'IPv4', 'direction': 'ingress'}
+        self.driver.create_security_group_rule(context=self.context,
+                                               group_id=3,
+                                               rule=rule)
+
+    def test_delete_security_group_rule(self):
+        rule = {'ethertype': 'IPv4', 'direction': 'ingress'}
+        self.driver.delete_security_group_rule(context=self.context,
+                                               group_id=3,
+                                               rule=rule)

--- a/quark/tests/test_db_custom_types.py
+++ b/quark/tests/test_db_custom_types.py
@@ -1,0 +1,76 @@
+# Copyright 2013 Openstack Foundation
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+#  under the License.
+
+from quark.db import custom_types
+
+from quark.tests import test_base
+
+from sqlalchemy.dialects import mysql, sqlite
+
+
+class TestDBCustomTypesINET(test_base.TestBase):
+    """Adding for coverage of the custom types."""
+
+    def setUp(self):
+        super(TestDBCustomTypesINET, self).setUp()
+        self.inet = custom_types.INET()
+
+    def test_inet_load_dialect_impl(self):
+        dialect = self.inet.load_dialect_impl(mysql.dialect())
+        self.assertEqual(type(dialect), type(custom_types.INET.impl()))
+
+    def test_inet_load_dialect_impl_sqlite(self):
+        dialect = self.inet.load_dialect_impl(sqlite.dialect())
+        self.assertEqual(type(dialect), sqlite.CHAR)
+
+    def test_process_bind_param(self):
+        bind = self.inet.process_bind_param(None, None)
+        self.assertIsNone(bind)
+
+    def test_process_bind_param_with_value(self):
+        bind = self.inet.process_bind_param("foo", sqlite.dialect())
+        self.assertEqual(bind, "foo")
+
+    def test_process_bind_param_with_value_not_sqlite(self):
+        bind = self.inet.process_bind_param("foo", mysql.dialect())
+        self.assertEqual(bind, "foo")
+
+    def test_process_result_value(self):
+        bind = self.inet.process_result_value(None, mysql.dialect())
+        self.assertIsNone(bind)
+
+    def test_process_result_value_with_value(self):
+        bind = self.inet.process_result_value(1.0, sqlite.dialect())
+        self.assertEqual(bind, 1.0)
+
+    def test_process_result_value_with_value_not_sqlite(self):
+        bind = self.inet.process_result_value(1.0, mysql.dialect())
+        self.assertEqual(bind, 1.0)
+
+
+class TestDBCustomTypesMACAddress(test_base.TestBase):
+    """Adding for coverage of the mac address custom types."""
+
+    def setUp(self):
+        super(TestDBCustomTypesMACAddress, self).setUp()
+        self.mac = custom_types.MACAddress()
+
+    def test_mac_load_dialect_impl(self):
+        dialect = self.mac.load_dialect_impl(sqlite.dialect())
+        self.assertEqual(type(dialect), sqlite.CHAR)
+
+    def test_mac_load_dialect_impl_not_sqlite(self):
+        dialect = self.mac.load_dialect_impl(mysql.dialect())
+        self.assertEqual(type(dialect), type(custom_types.MACAddress.impl()))


### PR DESCRIPTION
Adds more coverage tests for some portions of the driver logic and for
the db custom types. I decided to refrain from implementing some of the
optimized driver coverage tests at this time because the only thing one
can test there is that python and sqlalchemy work correctly. Otherwise,
they're just convenience methods.
