### PR TITLE
Re-implemented IP policies with offset and length

### DIFF
--- a/quark/api/extensions/ip_policies.py
+++ b/quark/api/extensions/ip_policies.py
@@ -42,6 +42,11 @@ class IPPoliciesController(wsgi.Controller):
         return {RESOURCE_NAME:
                 self._plugin.create_ip_policy(request.context, body)}
 
+    def update(self, request, id, body=None):
+        body = self._deserialize(request.body, request.get_content_type())
+        return {RESOURCE_NAME:
+                self._plugin.update_ip_policy(request.context, id, body)}
+
     def index(self, request):
         context = request.context
         return {RESOURCE_COLLECTION:

--- a/quark/db/api.py
+++ b/quark/db/api.py
@@ -489,13 +489,14 @@ def security_group_rule_delete(context, rule):
 
 def ip_policy_create(context, **ip_policy_dict):
     new_policy = models.IPPolicy()
-    exclude_set = ip_policy_dict.pop("exclude")
-    for ip_cidr in exclude_set.iter_cidrs():
-        new_policy["exclude"].append(models.IPPolicyRule(
-            address=int(ip_cidr.ip),
-            prefix=ip_cidr.prefixlen))
+    ranges = ip_policy_dict.pop("exclude")
+    for arange in ranges:
+        new_policy["exclude"].append(models.IPPolicyRange(
+            offset=arange["offset"],
+            length=arange["length"]))
 
     new_policy.update(ip_policy_dict)
+    new_policy["tenant_id"] = context.tenant_id
     context.session.add(new_policy)
     return new_policy
 
@@ -505,6 +506,20 @@ def ip_policy_find(context, **filters):
     query = context.session.query(models.IPPolicy)
     model_filters = _model_query(context, models.IPPolicy, filters)
     return query.filter(*model_filters)
+
+
+def ip_policy_update(context, ip_policy, **ip_policy_dict):
+    ranges = ip_policy_dict.pop("exclude", [])
+    if ranges:
+        ip_policy["exclude"] = []
+    for arange in ranges:
+        ip_policy["exclude"].append(models.IPPolicyRange(
+            offset=arange["offset"],
+            length=arange["length"]))
+
+    ip_policy.update(ip_policy_dict)
+    context.session.add(ip_policy)
+    return ip_policy
 
 
 def ip_policy_delete(context, ip_policy):

--- a/quark/exceptions.py
+++ b/quark/exceptions.py
@@ -65,5 +65,9 @@ class IPPolicyAlreadyExists(exceptions.NeutronException):
     message = _("IP Policy %(id)s already exists for %(n_id)s")
 
 
+class IPPolicyInUse(exceptions.InUse):
+    message = _("IP allocation policy %(id) in use.")
+
+
 class DriverLimitReached(exceptions.InvalidInput):
     message = _("Driver has reached limit on resource '%(limit)s'")

--- a/quark/plugin.py
+++ b/quark/plugin.py
@@ -149,6 +149,9 @@ class Plugin(neutron_plugin_base_v2.NeutronPluginBaseV2,
     def get_ip_policies(self, context, **filters):
         return ip_policies.get_ip_policies(context, **filters)
 
+    def update_ip_policy(self, context, id, ip_policy):
+        return ip_policies.update_ip_policy(context, id, ip_policy)
+
     def delete_ip_policy(self, context, id):
         return ip_policies.delete_ip_policy(context, id)
 

--- a/quark/plugin_modules/ip_policies.py
+++ b/quark/plugin_modules/ip_policies.py
@@ -13,8 +13,6 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
-import netaddr
-
 from neutron.common import exceptions
 from neutron.openstack.common import log as logging
 from oslo.config import cfg
@@ -23,10 +21,8 @@ from quark.db import api as db_api
 from quark import exceptions as quark_exceptions
 from quark import plugin_views as v
 
-
 CONF = cfg.CONF
 LOG = logging.getLogger("neutron.quark")
-DEFAULT_SG_UUID = "00000000-0000-0000-0000-000000000000"
 
 
 def create_ip_policy(context, ip_policy):
@@ -38,29 +34,35 @@ def create_ip_policy(context, ip_policy):
         raise exceptions.BadRequest(resource="ip_policy",
                                     msg="Empty ip_policy.exclude regions")
 
-    ipp["exclude"] = netaddr.IPSet(ipp["exclude"])
-    network_id = ipp.get("network_id")
-    subnet_id = ipp.get("subnet_id")
+    network_ids = ipp.get("network_ids")
+    subnet_ids = ipp.get("subnet_ids")
 
-    model = None
-    if subnet_id:
-        model = db_api.subnet_find(context, id=subnet_id, scope=db_api.ONE)
-        if not model:
-            raise exceptions.SubnetNotFound(id=subnet_id)
-    elif network_id:
-        model = db_api.network_find(context, id=network_id,
-                                    scope=db_api.ONE)
-        if not model:
-            raise exceptions.NetworkNotFound(id=network_id)
-    else:
+    if not subnet_ids and not network_ids:
         raise exceptions.BadRequest(
             resource="ip_policy",
-            msg="network_id or subnet_id unspecified")
+            msg="network_ids or subnet_ids not specified")
 
-    if model["ip_policy"]:
-        raise quark_exceptions.IPPolicyAlreadyExists(
-            id=model["ip_policy"]["id"], n_id=model["id"])
-    model["ip_policy"] = db_api.ip_policy_create(context, **ipp)
+    models = []
+    if subnet_ids:
+        subnets = db_api.subnet_find(
+            context, id=subnet_ids, scope=db_api.ALL)
+        if not subnets:
+            raise exceptions.SubnetNotFound(id=subnet_ids)
+        models.extend(subnets)
+
+    if network_ids:
+        nets = db_api.network_find(
+            context, id=network_ids, scope=db_api.ALL)
+        if not nets:
+            raise exceptions.NetworkNotFound(net_id=network_ids)
+        models.extend(nets)
+
+    for model in models:
+        if model["ip_policy"]:
+            raise quark_exceptions.IPPolicyAlreadyExists(
+                id=model["ip_policy"]["id"], n_id=model["id"])
+        model["ip_policy"] = db_api.ip_policy_create(context, **ipp)
+
     return v._make_ip_policy_dict(model["ip_policy"])
 
 
@@ -78,9 +80,51 @@ def get_ip_policies(context, **filters):
     return [v._make_ip_policy_dict(ipp) for ipp in ipps]
 
 
+def update_ip_policy(context, id, ip_policy):
+    LOG.info("update_ip_policy for tenant %s" % context.tenant_id)
+
+    ipp = ip_policy["ip_policy"]
+
+    ipp_db = db_api.ip_policy_find(context, id=id, scope=db_api.ONE)
+    if not ipp_db:
+        raise quark_exceptions.IPPolicyNotFound(id=id)
+
+    network_ids = ipp.get("network_ids")
+    subnet_ids = ipp.get("subnet_ids")
+
+    models = []
+    if subnet_ids:
+        for subnet in ipp_db["subnets"]:
+            subnet["ip_policy"] = None
+        subnets = db_api.subnet_find(
+            context, id=subnet_ids, scope=db_api.ALL)
+        if len(subnets) != len(subnet_ids):
+            raise exceptions.SubnetNotFound(id=subnet_ids)
+        models.extend(subnets)
+
+    if network_ids:
+        for network in ipp_db["networks"]:
+            network["ip_policy"] = None
+        nets = db_api.network_find(context, id=network_ids, scope=db_api.ALL)
+        if len(nets) != len(network_ids):
+            raise exceptions.NetworkNotFound(net_id=network_ids)
+        models.extend(nets)
+
+    for model in models:
+        if model["ip_policy"]:
+            raise quark_exceptions.IPPolicyAlreadyExists(
+                id=model["ip_policy"]["id"], n_id=model["id"])
+        model["ip_policy"] = ipp_db
+
+    ipp_db = db_api.ip_policy_update(context, ipp_db, **ipp)
+    return v._make_ip_policy_dict(ipp_db)
+
+
 def delete_ip_policy(context, id):
     LOG.info("delete_ip_policy %s for tenant %s" % (id, context.tenant_id))
     ipp = db_api.ip_policy_find(context, id=id, scope=db_api.ONE)
     if not ipp:
         raise quark_exceptions.IPPolicyNotFound(id=id)
+    if ipp["networks"] or ipp["subnets"]:
+        raise quark_exceptions.IPPolicyInUse(id=id)
     db_api.ip_policy_delete(context, ipp)


### PR DESCRIPTION
- Implemented CRUD ip_policies plugin methods
- Implemented plugin ip_policy unit tests
- Added IP Policy logic to ipam.allocate_ip_address
- Implemented ip_policy ipam unit tests
- Implemented ip_policies extension
- Added ip_policies db models
- Implemented db_api ip_policy methods
- Implemented _make_ip_policy_dict view
- Fixed existing tests

An IP Policy is defined on a subnet or network definining what IPs to
exclude from allocation. From a user perspective an IP Policy looks
like the following:

{
  "id": <id>,
  "tenant_id": <tenant_id>,
  "name": "foobar",
  "subnet_ids": [](list of uuids),
  "network_ids": [](list of uuids),
  "exclude": list of dictionaries (e.g. [{"offset": -1, "length": 3}])
}

"exclude" is always required. One of "subnet_ids" or "network_ids"
is required. Only one policy is allowed per network.

A default policy is enabled on all subnets if no ip policies are
specified on that subnet or its network. This default policy is
established via JSON configuration as "default_ip_policy". The
default for "default_ip_policy" is no policy.
