### PR TITLE
Fixes #158

### DIFF
--- a/quark/tests/test_db_models.py
+++ b/quark/tests/test_db_models.py
@@ -29,3 +29,15 @@ class TestDBModels(test_base.TestBase):
         ip_policy_rules = models.IPPolicy.get_ip_policy_rule_set(subnet)
         self.assertEqual(ip_policy_rules,
                          IPSet(['0.0.0.0/31', '0.0.0.255/32']))
+
+    def test_get_ip_policy_rule_set_v6(self):
+        subnet = dict(id=1, ip_version=6, next_auto_assign_ip=0,
+                      cidr="fc00::/7",
+                      first_ip=334965454937798799971759379190646833152L,
+                      last_ip=337623910929368631717566993311207522303L,
+                      network=dict(ip_policy=None), ip_policy=None)
+        ip_policy_rules = models.IPPolicy.get_ip_policy_rule_set(subnet)
+        self.assertEqual(
+            ip_policy_rules,
+            IPSet(["fc00::/127",
+                   "fdff:ffff:ffff:ffff:ffff:ffff:ffff:ffff/128"]))

--- a/quark/tests/test_ipam.py
+++ b/quark/tests/test_ipam.py
@@ -446,8 +446,8 @@ class TestQuarkIpPoliciesIpAllocation(QuarkIpamBaseTest):
         net = dict(ip_policy=dict(exclude=
                                   [dict(offset=0, length=2),
                                    dict(offset=254, length=1)]))
-        subnet = dict(id=1, first_ip=0, last_ip=63,
-                      cidr="0.0.0.0/30", ip_version=4,
+        subnet = dict(id=1, first_ip=0, last_ip=255,
+                      cidr="0.0.0.0/24", ip_version=4,
                       next_auto_assign_ip=0, network=net,
                       ip_policy=None)
         with self._stubs(subnets=[(subnet, 0)], addresses=[None, None]):


### PR DESCRIPTION
- Refactored IPPolicy.get_ip_policy_rule_set to use IPRange instead of
  IPNetwork index splicing because index splicing is not supported in netaddr
  for IPv6 networks.
- Added unit test case for IPv6 subnet for
  IPPolicy.get_ip_policy_rule_set
- Modified an IPAM unit test to have correct parameters for test's
  original intent.
