### PR TITLE
Ensure we're always trying to iterate over a list

### DIFF
--- a/quark/plugin_modules/networks.py
+++ b/quark/plugin_modules/networks.py
@@ -161,7 +161,7 @@ def get_networks(context, filters=None, fields=None):
     """
     LOG.info("get_networks for tenant %s with filters %s, fields %s" %
             (context.tenant_id, filters, fields))
-    nets = db_api.network_find(context, **filters)
+    nets = db_api.network_find(context, **filters) or []
     return [v._make_network_dict(net) for net in nets]
 
 


### PR DESCRIPTION
No associated test, because I can't reproduce it locally. An error I'm seeing in our dev environment involves nets coming back as None instead of an empty iterable. I'm going to blame a difference in sqlalchemy between my env and the dev env. For now, I know the patch takes care of the issue.
