### PR TITLE
Default net assignment

### DIFF
--- a/quark/__init__.py
+++ b/quark/__init__.py
@@ -25,9 +25,9 @@ quark_opts = [
                help=_('The client to use to talk to the backend')),
     cfg.StrOpt('ipam_driver', default='quark.ipam.QuarkIpam',
                help=_('IPAM Implementation to use')),
-    cfg.BoolOpt('ipam_reuse_after', default=7200,
-                help=_("Time in seconds til IP and MAC reuse"
-                       "after deallocation.")),
+    cfg.IntOpt('ipam_reuse_after', default=7200,
+               help=_("Time in seconds til IP and MAC reuse"
+                      "after deallocation.")),
     cfg.StrOpt("strategy_driver",
                default='quark.network_strategy.JSONStrategy',
                help=_("Tree of network assignment strategy")),

--- a/quark/plugin.py
+++ b/quark/plugin.py
@@ -18,13 +18,9 @@ v2 Neutron Plug-in API Quark Implementation
 """
 from oslo.config import cfg
 
-from sqlalchemy.orm import sessionmaker, scoped_session
-from zope import sqlalchemy as zsa
-
 from neutron.db import api as neutron_db_api
 from neutron.extensions import securitygroup as sg_ext
 from neutron import neutron_plugin_base_v2
-from neutron.openstack.common.db.sqlalchemy import session as neutron_session
 from neutron import quota
 
 from quark.api import extensions
@@ -79,15 +75,8 @@ class Plugin(neutron_plugin_base_v2.NeutronPluginBaseV2,
                                    "subnets_quark", "provider",
                                    "ip_policies", "quotas"]
 
-    def _initDBMaker(self):
-        # This needs to be called after _ENGINE is configured
-        session_maker = sessionmaker(bind=neutron_session._ENGINE,
-                                     extension=zsa.ZopeTransactionExtension())
-        neutron_session._MAKER = scoped_session(session_maker)
-
     def __init__(self):
         neutron_db_api.configure_db()
-        self._initDBMaker()
         neutron_db_api.register_models(base=models.BASEV2)
 
     def get_mac_address_range(self, context, id, fields=None):

--- a/quark/plugin_modules/mac_address_ranges.py
+++ b/quark/plugin_modules/mac_address_ranges.py
@@ -82,9 +82,10 @@ def create_mac_address_range(context, mac_range):
     LOG.info("create_mac_address_range for tenant %s" % context.tenant_id)
     cidr = mac_range["mac_address_range"]["cidr"]
     cidr, first_address, last_address = _to_mac_range(cidr)
-    new_range = db_api.mac_address_range_create(
-        context, cidr=cidr, first_address=first_address,
-        last_address=last_address, next_auto_assign_mac=first_address)
+    with context.session.begin():
+        new_range = db_api.mac_address_range_create(
+            context, cidr=cidr, first_address=first_address,
+            last_address=last_address, next_auto_assign_mac=first_address)
     return v._make_mac_range_dict(new_range)
 
 
@@ -103,8 +104,9 @@ def delete_mac_address_range(context, id):
     """
     LOG.info("delete_mac_address_range %s for tenant %s" %
              (id, context.tenant_id))
-    mar = db_api.mac_address_range_find(context, id=id, scope=db_api.ONE)
-    if not mar:
-        raise quark_exceptions.MacAddressRangeNotFound(
-            mac_address_range_id=id)
-    _delete_mac_address_range(context, mar)
+    with context.session.begin():
+        mar = db_api.mac_address_range_find(context, id=id, scope=db_api.ONE)
+        if not mar:
+            raise quark_exceptions.MacAddressRangeNotFound(
+                mac_address_range_id=id)
+        _delete_mac_address_range(context, mar)

--- a/quark/plugin_views.py
+++ b/quark/plugin_views.py
@@ -87,6 +87,7 @@ def _make_subnet_dict(subnet, default_route=None, fields=None):
            "allocation_pools": _allocation_pools(subnet),
            "dns_nameservers": dns_nameservers or [],
            "cidr": subnet.get("cidr"),
+           "shared": STRATEGY.is_parent_network(net_id),
            "enable_dhcp": None}
 
     def _host_route(route):

--- a/quark/tests/test_base.py
+++ b/quark/tests/test_base.py
@@ -24,3 +24,15 @@ class TestBase(unittest2.TestCase):
     def setUp(self):
         super(TestBase, self).setUp()
         self.context = context.Context('fake', 'fake', is_admin=False)
+
+        class FakeContext(object):
+            def __new__(cls, *args, **kwargs):
+                return super(FakeContext, cls).__new__(cls)
+
+            def __enter__(*args, **kwargs):
+                pass
+
+            def __exit__(*args, **kwargs):
+                pass
+
+        self.context.session.begin = FakeContext


### PR DESCRIPTION
Adds default network assignment to Quark, along with yanking out
repoze.tm2 for compatibility while reinstating the standard
sqlalchemy-style transaction sessions to eliminate the race condition in
mass-assigning IP addresses under load.
