### PR TITLE
Adds Network extensions resource

### DIFF
--- a/quark/api/extensions/networks.py
+++ b/quark/api/extensions/networks.py
@@ -1,0 +1,53 @@
+# Copyright (c) 2013 OpenStack Foundation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+RESOURCE_NAME = "network"
+RESOURCE_COLLECTION = RESOURCE_NAME + "s"
+EXTENDED_ATTRIBUTES_2_0 = {
+    RESOURCE_COLLECTION: {
+        "ipam_strategy": {"allow_post": False, "is_visible": True,
+                          "default": False}}}
+
+
+class Networks(object):
+    """Extends Networks for quark API purposes."""
+
+    @classmethod
+    def get_name(cls):
+        return "Quark Networks API Extension"
+
+    @classmethod
+    def get_alias(cls):
+        return "networks"
+
+    @classmethod
+    def get_description(cls):
+        return "Quark Networks API Extension"
+
+    @classmethod
+    def get_namespace(cls):
+        return ("http://docs.openstack.org/network/ext/"
+                "networks/api/v2.0")
+
+    @classmethod
+    def get_updated(cls):
+        return "2013-03-25T19:00:00-00:00"
+
+    def get_extended_resources(self, version):
+        if version == "2.0":
+            return EXTENDED_ATTRIBUTES_2_0
+        else:
+            return {}

--- a/quark/plugin_modules/networks.py
+++ b/quark/plugin_modules/networks.py
@@ -68,6 +68,7 @@ def create_network(context, network):
         #             lets make it work first
         pnet_type, phys_net, seg_id = _adapt_provider_nets(context, network)
         net_attrs = network["network"]
+        net_attrs["ipam_strategy"] = CONF.QUARK.default_ipam_strategy
 
         # NOTE(mdietz) I think ideally we would create the providernet
         # elsewhere as a separate driver step that could be

--- a/quark/plugin_views.py
+++ b/quark/plugin_views.py
@@ -37,6 +37,7 @@ def _make_network_dict(network, fields=None):
            "name": network.get("name"),
            "tenant_id": network.get("tenant_id"),
            "admin_state_up": None,
+           "ipam_strategy": network.get("ipam_strategy"),
            "status": "ACTIVE",
            "shared": shared_net,
            #TODO(mdietz): this is the expected return. Then the client

--- a/quark/tests/plugin_modules/test_networks.py
+++ b/quark/tests/plugin_modules/test_networks.py
@@ -206,7 +206,7 @@ class TestQuarkCreateNetwork(test_quark_plugin.TestQuarkPlugin):
         with self._stubs(net=net) as net_create:
             net = self.plugin.create_network(self.context, dict(network=net))
             self.assertTrue(net_create.called)
-            self.assertEqual(len(net.keys()), 7)
+            self.assertEqual(len(net.keys()), 8)
             self.assertIsNotNone(net["id"])
             self.assertEqual(net["name"], "public")
             self.assertIsNone(net["admin_state_up"])
@@ -214,6 +214,7 @@ class TestQuarkCreateNetwork(test_quark_plugin.TestQuarkPlugin):
             self.assertEqual(net["subnets"], [])
             self.assertEqual(net["shared"], False)
             self.assertEqual(net["tenant_id"], 0)
+            self.assertEqual(net["ipam_strategy"], None)
 
     def test_create_network_with_subnets(self):
         subnet = dict(id=2, cidr="172.168.0.0/24", tenant_id=0)
@@ -223,7 +224,7 @@ class TestQuarkCreateNetwork(test_quark_plugin.TestQuarkPlugin):
             net.update(dict(subnets=[dict(subnet=subnet)]))
             net = self.plugin.create_network(self.context, dict(network=net))
             self.assertTrue(net_create.called)
-            self.assertEqual(len(net.keys()), 7)
+            self.assertEqual(len(net.keys()), 8)
             self.assertIsNotNone(net["id"])
             self.assertEqual(net["name"], "public")
             self.assertIsNone(net["admin_state_up"])
@@ -231,6 +232,7 @@ class TestQuarkCreateNetwork(test_quark_plugin.TestQuarkPlugin):
             self.assertEqual(net["subnets"], [2])
             self.assertEqual(net["shared"], False)
             self.assertEqual(net["tenant_id"], 0)
+            self.assertEqual(net["ipam_strategy"], None)
 
 
 class TestQuarkDiagnoseNetworks(test_quark_plugin.TestQuarkPlugin):


### PR DESCRIPTION
Exposes the IPAM strategy associated with a network through a new
Networks API extension. Subsequent patches will update the API extension
to allow the strategy to be set on network create.
