### PR TITLE
Allows easier configuration of default networks

### DIFF
--- a/quark/api/extensions/networks_quark.py
+++ b/quark/api/extensions/networks_quark.py
@@ -18,11 +18,12 @@ RESOURCE_NAME = "network"
 RESOURCE_COLLECTION = RESOURCE_NAME + "s"
 EXTENDED_ATTRIBUTES_2_0 = {
     RESOURCE_COLLECTION: {
-        "ipam_strategy": {"allow_post": False, "is_visible": True,
-                          "default": False}}}
+        "ipam_strategy": {"allow_post": True, "is_visible": True,
+                          "default": False},
+        "id": {"allow_post": True, "is_visible": True, "default": False}}}
 
 
-class Networks(object):
+class Networks_quark(object):
     """Extends Networks for quark API purposes."""
 
     @classmethod
@@ -31,7 +32,7 @@ class Networks(object):
 
     @classmethod
     def get_alias(cls):
-        return "networks"
+        return "networks_quark"
 
     @classmethod
     def get_description(cls):
@@ -40,7 +41,7 @@ class Networks(object):
     @classmethod
     def get_namespace(cls):
         return ("http://docs.openstack.org/network/ext/"
-                "networks/api/v2.0")
+                "networks_quark/api/v2.0")
 
     @classmethod
     def get_updated(cls):

--- a/quark/exceptions.py
+++ b/quark/exceptions.py
@@ -1,6 +1,10 @@
 from neutron.common import exceptions
 
 
+class NetworkAlreadyExists(exceptions.Conflict):
+    message = _("Network %(id)s already exists.")
+
+
 class InvalidMacAddressRange(exceptions.NeutronException):
     message = _("Invalid MAC address range %(cidr)s.")
 
@@ -47,6 +51,10 @@ class SegmentIdRequired(exceptions.NeutronException):
 
 class PhysicalNetworkNotFound(exceptions.NeutronException):
     message = _("Physical network %(phys_net)s not found!")
+
+
+class InvalidIpamStrategy(exceptions.BadRequest):
+    message = _("IPAM Strategy %(strat)s is invalid.")
 
 
 class ProvidernetParamError(exceptions.NeutronException):

--- a/quark/ipam.py
+++ b/quark/ipam.py
@@ -306,8 +306,13 @@ class IpamRegistry(object):
             QuarkIpamBOTH.get_name(): QuarkIpamBOTH(),
             QuarkIpamBOTHREQ.get_name(): QuarkIpamBOTHREQ()}
 
-    def get_strategy(self, strategy_name):
+    def is_valid_strategy(self, strategy_name):
         if strategy_name in self.strategies:
+            return True
+        return False
+
+    def get_strategy(self, strategy_name):
+        if self.is_valid_strategy(strategy_name):
             return self.strategies[strategy_name]
         fallback = CONF.QUARK.default_ipam_strategy
         LOG.warn("IPAM strategy %s not found, "

--- a/quark/plugin.py
+++ b/quark/plugin.py
@@ -73,7 +73,8 @@ class Plugin(neutron_plugin_base_v2.NeutronPluginBaseV2,
                                    "ip_addresses", "ports_quark",
                                    "security-group", "diagnostics",
                                    "subnets_quark", "provider",
-                                   "ip_policies", "quotas"]
+                                   "ip_policies", "quotas",
+                                   "networks_quark"]
 
     def __init__(self):
         neutron_db_api.configure_db()


### PR DESCRIPTION
Updates the Quark networks extension to allow the id and ipam_strategy
to be passed along with a network create. The id is specifically gated
as admin only, but as an admin, allows deployers to configure special
networks like the all 0s and 1s placeholder values we use at Rackspace.
