### PR TITLE
Fixes #169

### DIFF
--- a/quark/db/models.py
+++ b/quark/db/models.py
@@ -140,6 +140,7 @@ class IPAddress(BASEV2, models.HasId, models.HasTenant):
     version = sa.Column(sa.Integer())
 
     allocated_at = sa.Column(sa.DateTime())
+    subnet = orm.relationship("Subnet", lazy="joined")
 
     # Need a constant to facilitate the indexed search for new IPs
     _deallocated = sa.Column(sa.Boolean())
@@ -229,9 +230,7 @@ class Subnet(BASEV2, models.HasId, models.HasTenant, IsHazTags):
 
     allocated_ips = orm.relationship(IPAddress,
                                      primaryjoin='and_(Subnet.id=='
-                                     'IPAddress.subnet_id, '
-                                     'IPAddress._deallocated!=1)',
-                                     backref="subnet")
+                                     'IPAddress.subnet_id)')
     routes = orm.relationship(Route, primaryjoin="Route.subnet_id==Subnet.id",
                               backref='subnet', cascade='delete')
     enable_dhcp = sa.Column(sa.Boolean(), default=False)


### PR DESCRIPTION
We were unnecessarily checking whether or not an IP was actually
allocated in the subnet_find_allocation_count check. The reality is we
only care if the IP has been generated before, not whether or not it's
actually been allocated. The reason is by the time check the counts in
the database, we've already failed our attempt to reallocate from one of
the subnets. If we assume that no IPs are available for reallocation,
the next step is finding a subnet we can generate a _new_ IP address in.

Also, adds checking to ensure we never accidentally reassign an
incorrectly generated IP address. Additionally, the patch takes the
proactive step of deleting the offending IP address altogether. Note
that it only touches deallocated and available IPs.
